### PR TITLE
ClientStub

### DIFF
--- a/Daml.Ledger.Builder.csproj
+++ b/Daml.Ledger.Builder.csproj
@@ -3,7 +3,7 @@
   <Target Name="Build" DependsOnTargets="AutoBuild">
   </Target>
 
-  <Target Name="AutoBuild" DependsOnTargets="Reactive;Automation;BindingsExample;TestExample">
+  <Target Name="AutoBuild" DependsOnTargets="ClientTest;ReactiveTest;Automation;BindingsExample;TestExample">
   </Target>
 
   <Target Name="Api">
@@ -23,6 +23,13 @@
   <Target Name="Client" DependsOnTargets="Api;Fragment">
     <PropertyGroup>
       <Project>Daml.Ledger.Client</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="ClientTest" DependsOnTargets="Client">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Client.Test</Project>
     </PropertyGroup>
     <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
   </Target>

--- a/Daml.Ledger.sln
+++ b/Daml.Ledger.sln
@@ -39,9 +39,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Examples.Bindin
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022} = {68C093F1-5FA2-4DA9-8A84-50782FAAF022}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daml.Ledger.Client.Reactive.Test", "src\Daml.Ledger.Client.Reactive.Test\Daml.Ledger.Client.Reactive.Test.csproj", "{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Client.Reactive.Test", "src\Daml.Ledger.Client.Reactive.Test\Daml.Ledger.Client.Reactive.Test.csproj", "{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}"
 	ProjectSection(ProjectDependencies) = postProject
 		{C28365C5-6F64-4468-8FFC-93121553C2EA} = {C28365C5-6F64-4468-8FFC-93121553C2EA}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Client.Test", "src\Daml.Ledger.Client.Test\Daml.Ledger.Client.Test.csproj", "{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}"
+	ProjectSection(ProjectDependencies) = postProject
+		{658CEB77-4F21-40B9-9963-896C41E64B67} = {658CEB77-4F21-40B9-9963-896C41E64B67}
 	EndProjectSection
 EndProject
 Global
@@ -146,10 +151,22 @@ Global
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Release|x86.ActiveCfg = Release|Any CPU
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Release|x86.Build.0 = Release|Any CPU
-		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|Any CPU.ActiveCfg = ReleaseNuget|Any CPU
-		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|Any CPU.Build.0 = ReleaseNuget|Any CPU
-		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|x86.ActiveCfg = ReleaseNuget|Any CPU
-		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|x86.Build.0 = ReleaseNuget|Any CPU
+		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.ReleaseNuget|x86.Build.0 = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.Release|x86.Build.0 = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{71F8ADAE-571A-4AF5-8830-F8C9EBE091DE}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Daml.Ledger.Client.Test/Auth/Client/ClientStubTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/ClientStubTest.cs
@@ -1,0 +1,67 @@
+// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Daml.Ledger.Client.Auth.Client;
+using Google.Api;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace Daml.Ledger.Client.Test.Auth.Client
+{
+    public class ServiceClient
+    {
+        public MeaningOfLifeResponse WhatIsTheMeaningOfLife(MeaningOfLifeRequest request, CallOptions callOptions) => new MeaningOfLifeResponse();
+    }
+
+    public class MeaningOfLifeRequest
+    {
+    }
+
+    public class MeaningOfLifeResponse
+    {
+        public int MeaningOfLife = 42;
+    }
+
+    [TestFixture]
+    public class ClientStubTest
+    {
+        [Test]
+        public void SimpleCallExample()
+        {
+            var stub = new ClientStub<ServiceClient>(new ServiceClient());
+
+            var response = stub.Dispatch(new MeaningOfLifeRequest(), (c, r, o) => c.WhatIsTheMeaningOfLife(r, o));
+            Assert.AreEqual(42, response.MeaningOfLife);
+        }
+
+        [Test]
+        public void WithNonEmptyAccessTokenGeneratesNewStub()
+        {
+            var stub = new ClientStub<ServiceClient>(new ServiceClient());
+
+            var stub2 = stub.WithAccess("accessToken");
+
+            Assert.AreNotEqual(stub, stub2);
+        }
+
+        [Test]
+        public void WithEmptyAccessTokenReturnsSameStub()
+        {
+            var stub = new ClientStub<ServiceClient>(new ServiceClient());
+
+            var stub2 = stub.WithAccess(null);
+
+            Assert.AreEqual(stub, stub2);
+        }
+
+        [Test]
+        public void WithDuplicateAccessTokenReturnsSameStub()
+        {
+            var stub = new ClientStub<ServiceClient>(new ServiceClient(), "accessToken");
+
+            var stub2 = stub.WithAccess("accessToken");
+
+            Assert.AreEqual(stub, stub2);
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallCredentialsTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallCredentialsTest.cs
@@ -1,0 +1,30 @@
+// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using NUnit.Framework;
+using Daml.Ledger.Client.Auth.Client;
+
+namespace Daml.Ledger.Client.Test.Auth.Client
+{
+    [TestFixture]
+    public class LedgerCallOptionsTest
+    {
+        [Test]
+        public void NullCallOptionReturnedForEmptyAccessToken()
+        {
+            CallOptions? callOptions = LedgerCallOptions.MakeCallOptions((string) null);
+            Assert.IsNull(callOptions);
+        }
+
+        [Test]
+        public void NullCallOptionReturnedForEmptyAccessTokens()
+        {
+            CallOptions? callOptions = LedgerCallOptions.MakeCallOptions(new string[] { null, string.Empty, null });
+            Assert.IsNull(callOptions);
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallOptionsTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallOptionsTest.cs
@@ -1,0 +1,95 @@
+// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using NUnit.Framework;
+using Daml.Ledger.Client.Auth.Client;
+
+namespace Daml.Ledger.Client.Test.Auth.Client
+{
+    [TestFixture]
+    public class LedgerCallCredentialsTest
+    {
+        [Test]
+        public void CanCreateAuthInterceptorForAccessToken()
+        {
+            AsyncAuthInterceptor asyncAuthInterceptor = LedgerCallCredentials.MakeAsyncAuthInterceptor("myAccessToken");
+
+            Metadata metaData = new Metadata();
+
+            Task task = asyncAuthInterceptor(new AuthInterceptorContext("url", "method"), metaData);
+
+            Assert.IsTrue(task.IsCompleted);
+            Assert.AreEqual(1, metaData.Count);
+            var entry = metaData.First();
+            Assert.AreEqual("authorization", entry.Key);
+            Assert.AreEqual("myAccessToken", entry.Value);
+        }
+
+        [Test]
+        public void InterceptorDoesNothingForEmptyAccessToken()
+        {
+            AsyncAuthInterceptor asyncAuthInterceptor = LedgerCallCredentials.MakeAsyncAuthInterceptor((string) null);
+
+            Metadata metaData = new Metadata();
+
+            Task task = asyncAuthInterceptor(new AuthInterceptorContext("url", "method"), metaData);
+
+            Assert.IsTrue(task.IsCompleted);
+            Assert.AreEqual(0, metaData.Count);
+        }
+
+        [Test]
+        public void CanCreateAuthInterceptorForAccessTokens()
+        {
+            AsyncAuthInterceptor asyncAuthInterceptor = LedgerCallCredentials.MakeAsyncAuthInterceptor(new [] { "accessToken1", "accessToken2", "accessToken3" });
+
+            Metadata metaData = new Metadata();
+
+            Task task = asyncAuthInterceptor(new AuthInterceptorContext("url", "method"), metaData);
+
+            Assert.IsTrue(task.IsCompleted);
+            Assert.AreEqual(3, metaData.Count);
+            int i = 1;
+            foreach (var entry in metaData)
+            {
+                Assert.AreEqual("authorization", entry.Key);
+                Assert.AreEqual($"accessToken{i++}", entry.Value);
+            }
+        }
+
+        [Test]
+        public void InterceptorDoesNothingForEmptyAccessTokens()
+        {
+            AsyncAuthInterceptor asyncAuthInterceptor = LedgerCallCredentials.MakeAsyncAuthInterceptor(new List<string>());
+
+            Metadata metaData = new Metadata();
+
+            Task task = asyncAuthInterceptor(new AuthInterceptorContext("url", "method"), metaData);
+
+            Assert.IsTrue(task.IsCompleted);
+            Assert.AreEqual(0, metaData.Count);
+        }
+
+        [Test]
+        public void InterceptorCopesWithSparseAccessTokens()
+        {
+            AsyncAuthInterceptor asyncAuthInterceptor = LedgerCallCredentials.MakeAsyncAuthInterceptor(new[] { "accessToken1", null, "accessToken2", string.Empty, "accessToken3" });
+
+            Metadata metaData = new Metadata();
+
+            Task task = asyncAuthInterceptor(new AuthInterceptorContext("url", "method"), metaData);
+
+            Assert.IsTrue(task.IsCompleted);
+            int i = 1;
+            foreach (var entry in metaData)
+            {
+                Assert.AreEqual("authorization", entry.Key);
+                Assert.AreEqual($"accessToken{i++}", entry.Value);
+            }
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Test/Daml.Ledger.Client.Test.csproj
+++ b/src/Daml.Ledger.Client.Test/Daml.Ledger.Client.Test.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>Daml.Ledger.Client.Test</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseNuget' ">
+    <DebugType></DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\ReleaseNuget</OutputPath>
+    <DefineConstants></DefineConstants>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>obj\ReleaseNuget</IntermediateOutputPath>
+    <NoWarn></NoWarn>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Daml.Ledger.Client.Test/nuget.config
+++ b/src/Daml.Ledger.Client.Test/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="../../packages" />
+  </packageSources>
+</configuration>

--- a/src/Daml.Ledger.Client/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/ActiveContractsClient.cs
@@ -5,17 +5,18 @@ namespace Daml.Ledger.Client
 {
     using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class ActiveContractsClient : IActiveContractsClient
     {
         private readonly string _ledgerId;
-        private readonly ActiveContractsService.ActiveContractsServiceClient _activeContractsClient;
+        private readonly ClientStub<ActiveContractsService.ActiveContractsServiceClient> _activeContractsClient;
 
         public ActiveContractsClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _activeContractsClient = new ActiveContractsService.ActiveContractsServiceClient(channel);
+            _activeContractsClient = new ClientStub<ActiveContractsService.ActiveContractsServiceClient>(new ActiveContractsService.ActiveContractsServiceClient(channel));
         }
 
         public IAsyncEnumerator<GetActiveContractsResponse> GetActiveContracts(
@@ -24,7 +25,7 @@ namespace Daml.Ledger.Client
             TraceContext traceContext = null)
         {
             var request = new GetActiveContractsRequest { LedgerId = _ledgerId, Filter = transactionFilter, Verbose = verbose, TraceContext = traceContext };
-            var response = _activeContractsClient.GetActiveContracts(request);
+            var response = _activeContractsClient.Dispatch(request, (c, r, co) => c.GetActiveContracts(r, co));
             return response.ResponseStream;
         }
 

--- a/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
@@ -7,26 +7,27 @@ namespace Daml.Ledger.Client.Admin
     using System.Threading.Tasks;
     using Grpc.Core;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
+    using Daml.Ledger.Client.Auth.Client;
     using Google.Protobuf.WellKnownTypes;
 
     public class ConfigManagementClient : IConfigManagementClient
     {
-        private readonly ConfigManagementService.ConfigManagementServiceClient _configManagementClient;
+        private readonly ClientStub<ConfigManagementService.ConfigManagementServiceClient> _configManagementClient;
 
         public ConfigManagementClient(Channel channel)
         {
-            _configManagementClient = new ConfigManagementService.ConfigManagementServiceClient(channel);
+            _configManagementClient = new ClientStub<ConfigManagementService.ConfigManagementServiceClient>(new Com.DigitalAsset.Ledger.Api.V1.Admin.ConfigManagementService.ConfigManagementServiceClient(channel));
         }
 
         public (TimeModel, long) GetTimeModel()
         {
-            var response = _configManagementClient.GetTimeModel(new GetTimeModelRequest());
+            var response = _configManagementClient.Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModel(r, co));
             return (response.TimeModel, response.ConfigurationGeneration);
         }
 
         public async Task<(TimeModel, long)> GetTimeModelAsync()
         {
-            var response = await _configManagementClient.GetTimeModelAsync(new GetTimeModelRequest());
+            var response = await _configManagementClient.Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModelAsync(r, co));
             return (response.TimeModel, response.ConfigurationGeneration);
         }
 
@@ -34,14 +35,14 @@ namespace Daml.Ledger.Client.Admin
         {
             var request = new SetTimeModelRequest { SubmissionId = submissionId, ConfigurationGeneration = configurationGeneration, MaximumRecordTime = Timestamp.FromDateTime(maximumRecordTime), NewTimeModel = newTimeModel };
 
-            return _configManagementClient.SetTimeModel(request).ConfigurationGeneration;
+            return _configManagementClient.Dispatch(request, (c, r, co) => c.SetTimeModel(r, co).ConfigurationGeneration);
         }
 
         public async Task<long> SetTimeModelAsync(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel)
         {
             var request = new SetTimeModelRequest { SubmissionId = submissionId, ConfigurationGeneration = configurationGeneration, MaximumRecordTime = Timestamp.FromDateTime(maximumRecordTime), NewTimeModel = newTimeModel };
 
-            var response = await _configManagementClient.SetTimeModelAsync(request);
+            var response = await _configManagementClient.Dispatch(request, (c, r, co) => c.SetTimeModelAsync(r, co));
                 
             return response.ConfigurationGeneration;
         }

--- a/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
@@ -7,27 +7,28 @@ namespace Daml.Ledger.Client.Admin
     using System.IO;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
+    using Daml.Ledger.Client.Auth.Client;
     using Google.Protobuf;
     using Grpc.Core;
 
     public class PackageManagementClient : IPackageManagementClient
     {
-        private readonly PackageManagementService.PackageManagementServiceClient _packageManagementClient;
+        private readonly ClientStub<PackageManagementService.PackageManagementServiceClient> _packageManagementClient;
 
         public PackageManagementClient(Channel channel)
         {
-            _packageManagementClient = new PackageManagementService.PackageManagementServiceClient(channel);
+            _packageManagementClient = new ClientStub<PackageManagementService.PackageManagementServiceClient>(new PackageManagementService.PackageManagementServiceClient(channel));
         }
 
         public IEnumerable<PackageDetails> ListKnownPackages()
         {
-            var response = _packageManagementClient.ListKnownPackages(new ListKnownPackagesRequest());
+            var response = _packageManagementClient.Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackages(r, co));
             return response.PackageDetails;
         }
 
         public async Task<IEnumerable<PackageDetails>> ListKnownPackagesAsync()
         {
-            var response = await _packageManagementClient.ListKnownPackagesAsync(new ListKnownPackagesRequest());
+            var response = await _packageManagementClient.Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackagesAsync(r, co));
             return response.PackageDetails;
         }
 
@@ -37,7 +38,7 @@ namespace Daml.Ledger.Client.Admin
             if (!string.IsNullOrEmpty(submissionId))
                 request.SubmissionId = submissionId;
             
-            _packageManagementClient.UploadDarFile(request);
+            _packageManagementClient.Dispatch(request, (c, r, co) => c.UploadDarFile(r, co));
         }
 
         public async Task UploadDarFileAsync(Stream stream, string submissionId = null)
@@ -47,7 +48,7 @@ namespace Daml.Ledger.Client.Admin
             if (!string.IsNullOrEmpty(submissionId))
                 request.SubmissionId = submissionId;
                 
-            await _packageManagementClient.UploadDarFileAsync(request);
+            await _packageManagementClient.Dispatch(request, (c, r, co) => c.UploadDarFileAsync(r, co));
         }
     }
 }

--- a/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
@@ -6,52 +6,53 @@ namespace Daml.Ledger.Client.Admin
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class PartyManagementClient : IPartyManagementClient
     {
-        private readonly PartyManagementService.PartyManagementServiceClient _partyManagementClient;
+        private readonly ClientStub<PartyManagementService.PartyManagementServiceClient> _partyManagementClient;
 
         public PartyManagementClient(Channel channel)
         {
-            _partyManagementClient = new PartyManagementService.PartyManagementServiceClient(channel);
+            _partyManagementClient = new ClientStub<PartyManagementService.PartyManagementServiceClient>(new PartyManagementService.PartyManagementServiceClient(channel));
         }
 
         public PartyDetails AllocateParty(string displayName, string partyIdHint)
         {
             var request = new AllocatePartyRequest { DisplayName = displayName, PartyIdHint = partyIdHint };
-            var response = _partyManagementClient.AllocateParty(request);
+            var response = _partyManagementClient.Dispatch(request, (c, r, co) => c.AllocateParty(r, co));
             return response.PartyDetails;
         }
 
         public async Task<PartyDetails> AllocatePartyAsync(string displayName, string partyIdHint)
         {
             var request = new AllocatePartyRequest { DisplayName = displayName, PartyIdHint = partyIdHint };
-            var response = await _partyManagementClient.AllocatePartyAsync(request);
+            var response = await _partyManagementClient.Dispatch(request, (c, r, co) => c.AllocatePartyAsync(r, co));
             return response.PartyDetails;
         }
 
         public string GetParticipantId()
         {
-            var response = _partyManagementClient.GetParticipantId(new GetParticipantIdRequest());
+            var response = _partyManagementClient.Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantId(r, co));
             return response.ParticipantId;
         }
 
         public async Task<string> GetParticipantIdAsync()
         {
-            var response = await _partyManagementClient.GetParticipantIdAsync(new GetParticipantIdRequest());
+            var response = await _partyManagementClient.Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantIdAsync(r, co));
             return response.ParticipantId;
         }
 
         public IEnumerable<PartyDetails> ListKnownParties()
         {
-            var response = _partyManagementClient.ListKnownParties(new ListKnownPartiesRequest());
+            var response = _partyManagementClient.Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownParties(r, co));
             return response.PartyDetails;
         }
 
         public async Task<IEnumerable<PartyDetails>> ListKnownPartiesAsync()
         {
-            var response = await _partyManagementClient.ListKnownPartiesAsync(new ListKnownPartiesRequest());
+            var response = await _partyManagementClient.Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownPartiesAsync(r, co));
             return response.PartyDetails;
         }
     }

--- a/src/Daml.Ledger.Client/AssemblyInfo.cs
+++ b/src/Daml.Ledger.Client/AssemblyInfo.cs
@@ -2,34 +2,4 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-// [assembly: AssemblyTitle("Daml.Ledger.Client")]
-// [assembly: AssemblyDescription("")]
-// [assembly: AssemblyConfiguration("")]
-// [assembly: AssemblyCompany("HP Inc.")]
-// [assembly: AssemblyProduct("Daml.Ledger.Client")]
-// [assembly: AssemblyCopyright("Copyright © HP Inc. 2020")]
-// [assembly: AssemblyTrademark("")]
-// [assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-// [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-// [assembly: Guid("8a07fafb-9a8e-49df-8c4e-be3eb79b9ec2")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// [assembly: AssemblyVersion("1.0.0.0")]
-// [assembly: AssemblyFileVersion("1.0.0.0")]
-
 [assembly: InternalsVisibleTo("Daml.Ledger.Client.Test")]

--- a/src/Daml.Ledger.Client/AssemblyInfo.cs
+++ b/src/Daml.Ledger.Client/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+// [assembly: AssemblyTitle("Daml.Ledger.Client")]
+// [assembly: AssemblyDescription("")]
+// [assembly: AssemblyConfiguration("")]
+// [assembly: AssemblyCompany("HP Inc.")]
+// [assembly: AssemblyProduct("Daml.Ledger.Client")]
+// [assembly: AssemblyCopyright("Copyright © HP Inc. 2020")]
+// [assembly: AssemblyTrademark("")]
+// [assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+// [assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+// [assembly: Guid("8a07fafb-9a8e-49df-8c4e-be3eb79b9ec2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// [assembly: AssemblyVersion("1.0.0.0")]
+// [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("Daml.Ledger.Client.Test")]

--- a/src/Daml.Ledger.Client/Auth/Client/ClientStub.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/ClientStub.cs
@@ -1,0 +1,99 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Daml.Ledger.Client.Auth.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using Grpc.Core;
+
+    /// <summary>
+    /// A stub around a gRPC client class, to ease management of access tokens. So named to mimic the Java use case somewhat.
+    /// </summary>
+    /// <typeparam name="TClient"></typeparam>
+    public class ClientStub<TClient> where TClient : class
+    {
+        private readonly TClient _client;
+        private readonly HashSet<string> _accessTokens;
+        private readonly CallOptions _callOptions;
+
+        /// <summary>
+        /// Construct with an optional access token to be specified on every call to the client class
+        /// </summary>
+        /// <param name="client">The grpc client class</param>
+        /// <param name="accessToken">An optional access token</param>
+        public ClientStub(TClient client, string accessToken = null)
+        {
+            _client = client;
+            _callOptions = new CallOptions();
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                _accessTokens = new HashSet<string>(new[] { accessToken });
+                _callOptions = _callOptions.WithCredentials(LedgerCallCredentials.MakeCallCredentials(accessToken));
+            }
+        }
+
+        /// <summary>
+        /// Return a stub modified to use the optional access token. If none is provided just return this - makes the calling sequence easier.
+        /// Note that we cope if the access token has already been specified
+        /// </summary>
+        /// <param name="accessToken">An optional access token</param>
+        /// <returns></returns>
+        public ClientStub<TClient> WithAccess(string accessToken = null)
+        {
+            ClientStub<TClient> clientStub = this;
+
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                HashSet<string> accessTokens = _accessTokens ?? new HashSet<string>();
+
+                // Only return a new stub itf we haven't already seen this token    
+                if (accessTokens.Add(accessToken))
+                    clientStub = new ClientStub<TClient>(_client, accessTokens);
+            }
+
+            return clientStub;
+        }
+
+        /// <summary>
+        /// Dispatch a request to the client.
+        ///
+        /// Each API method on the client has two forms:
+        ///
+        /// - one that accepts the request object and then a series of defaulted argument
+        /// - another that accepts the request object and a CallOptions object.
+        /// 
+        /// The first form creates a CallOptions object from its (possibly defaulted) argument and calls the second form of the API method.
+        ///
+        /// This method the accepts the request object and a functor that accepts the request object and a CallOptions object that we create. If access tokens were specified, this CallOptions
+        /// object will have its CallCredentials set, otherwise it will just be a default constructed CallOptions.
+        ///
+        /// If the caller wishes to set any of the the arguments that were available in the first form of the client API method, they should instead set them on the supplied CallOptions
+        /// object through its Builder interface.
+        ///
+        /// Hopefully this should cover all use cases.
+        /// </summary>
+        /// <typeparam name="TRequest">The request object type</typeparam>
+        /// <typeparam name="TResponse">The response object type, may be a Grpc.Core.AsyncUnaryCall when Async methods on the client object are specified in the functors</typeparam>
+        /// <param name="request">The request object</param>
+        /// <param name="func">A functor that accepts the request object and a CallOptions object</param>
+        /// <returns></returns>
+        public TResponse Dispatch<TRequest, TResponse>(TRequest request, Func<TClient, TRequest, CallOptions, TResponse> func)
+        {
+            return func(_client, request, _callOptions);
+        }
+
+        /// <summary>
+        /// A copy constructor for building a new object with an extra access token
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="accessTokens"></param>
+        private ClientStub(TClient client, HashSet<string> accessTokens)
+        {
+            _client = client;
+            _accessTokens = accessTokens;
+            _callOptions = _callOptions.WithCredentials(LedgerCallCredentials.MakeCallCredentials(_accessTokens));
+        }
+    }
+}

--- a/src/Daml.Ledger.Client/Auth/Client/LedgerCallCredentials.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/LedgerCallCredentials.cs
@@ -1,0 +1,58 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Daml.Ledger.Client.Auth.Client
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Grpc.Core;
+    using Grpc.Core.Utils;
+
+    /// <summary>
+    ///  See https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs and https://docs.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz?view=aspnetcore-3.1 for guidance/inspiration
+    /// </summary>
+    public class LedgerCallCredentials
+    {
+        /// <summary>
+        /// Return a CallCredentials that will set the specified access token in the Authorization metadata, if it is not null or empty.
+        /// </summary>
+        /// <param name="accessToken"></param>
+        /// <returns>A CallCredentials object</returns>
+        public static CallCredentials MakeCallCredentials(string accessToken)
+        {
+            return CallCredentials.FromInterceptor(MakeAsyncAuthInterceptor(accessToken));
+        }
+
+        /// <summary>
+        /// Return a CallCredentials that will set the specified non-empty access tokens in the Authorization metadata.
+        /// </summary>
+        /// <param name="accessTokens"></param>
+        /// <returns>A CallCredentials object</returns>
+        public static CallCredentials MakeCallCredentials(IEnumerable<string> accessTokens)
+        {
+            return CallCredentials.FromInterceptor(MakeAsyncAuthInterceptor(accessTokens));
+        }
+
+        internal static AsyncAuthInterceptor MakeAsyncAuthInterceptor(string accessToken)
+        {
+            return (context, metadata) =>
+            {
+                if (!string.IsNullOrEmpty(accessToken))
+                    metadata.Add(AuthorizationKeyName, accessToken);
+                return TaskUtils.CompletedTask;
+            };
+        }
+
+        internal static AsyncAuthInterceptor MakeAsyncAuthInterceptor(IEnumerable<string> accessTokens)
+        {
+            // If no valid tokens then we will return an async auth interceptor but it won't do anything... 
+            return (context, metadata) =>
+            {
+                accessTokens.Where(t => !string.IsNullOrEmpty(t)).Distinct().Select(t => t).ToList().ForEach(t => metadata.Add(AuthorizationKeyName, t)); // Should be merged so only one header key
+                return TaskUtils.CompletedTask;
+            };
+        }
+
+        private const string AuthorizationKeyName = "authorization";  // Seems like the Grpc code converts this to lowercase anyway
+    }
+}

--- a/src/Daml.Ledger.Client/Auth/Client/LedgerCallOptions.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/LedgerCallOptions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Daml.Ledger.Client.Auth.Client
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Grpc.Core;
+
+    /// <summary>
+    ///  See https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs and https://docs.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz?view=aspnetcore-3.1 for guidance/inspiration
+    /// </summary>
+    public class LedgerCallOptions
+    {
+        /// <summary>
+        /// Make a CallOptions object with the specified access token for passing to the Ledger API for authentication.
+        /// If the access token is null or empty then a null(able) is returned
+        /// </summary>
+        /// <param name="accessToken"></param>
+        /// <returns>A CallOptions object or null</returns>
+        public static CallOptions? MakeCallOptions(string accessToken)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+                return null;
+
+            return new CallOptions().WithCredentials(LedgerCallCredentials.MakeCallCredentials(accessToken));
+        }
+
+        /// <summary>
+        /// Make a CallOptions object with the specified access tokens for passing to the Ledger API for authentication.
+        /// If there are no non-null/non-empty access tokens then a null(able) is returned
+        /// </summary>
+        /// <param name="accessTokens"></param>
+        /// <returns>A CallOptions object or null</returns>
+        public static CallOptions? MakeCallOptions(IEnumerable<string> accessTokens)
+        {
+            var tokens = accessTokens.Where(t => !string.IsNullOrEmpty(t)).Distinct().Select(t => t).ToList();
+
+            if (tokens.Count == 0)
+                return null;
+
+            return new CallOptions().WithCredentials(LedgerCallCredentials.MakeCallCredentials(tokens));
+        }
+    }
+}

--- a/src/Daml.Ledger.Client/CommandClient.cs
+++ b/src/Daml.Ledger.Client/CommandClient.cs
@@ -7,18 +7,19 @@ namespace Daml.Ledger.Client
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Google.Protobuf.WellKnownTypes;
     using Grpc.Core;
 
     public class CommandClient : ICommandClient
     {
         private readonly string _ledgerId;
-        private readonly CommandService.CommandServiceClient _commandClient;
+        private readonly ClientStub<CommandService.CommandServiceClient> _commandClient;
 
         public CommandClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _commandClient = new CommandService.CommandServiceClient(channel);
+            _commandClient = new ClientStub<CommandService.CommandServiceClient>(new CommandService.CommandServiceClient(channel));
         }
 
         public void SubmitAndWait(
@@ -47,12 +48,12 @@ namespace Daml.Ledger.Client
 
         public void SubmitAndWait(Commands commands)
         {
-            _commandClient.SubmitAndWait(new SubmitAndWaitRequest { Commands = commands });
+            _commandClient.Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWait(r, co));
         }
 
         public async Task SubmitAndWaitAsync(Commands commands)
         {
-            await _commandClient.SubmitAndWaitAsync(new SubmitAndWaitRequest { Commands = commands });
+            await _commandClient.Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWaitAsync(r, co));
         }
 
         public Transaction SubmitAndWaitForTransaction(
@@ -65,7 +66,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.SubmitAndWaitForTransaction(request);
+            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransaction(r, co));
             return response.Transaction;
         }
 
@@ -79,7 +80,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.SubmitAndWaitForTransactionId(request);
+            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionId(r, co));
             return response.TransactionId;
         }
 
@@ -93,7 +94,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.SubmitAndWaitForTransactionTree(request);
+            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTree(r, co));
             return response.Transaction;
         }
 
@@ -107,7 +108,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.SubmitAndWaitForTransactionAsync(request);
+            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionAsync(r, co));
             return response.Transaction;
         }
 
@@ -121,7 +122,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.SubmitAndWaitForTransactionIdAsync(request);
+            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionIdAsync(r, co));
             return response.TransactionId;
         }
 
@@ -135,7 +136,7 @@ namespace Daml.Ledger.Client
             IEnumerable<Command> commands)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.SubmitAndWaitForTransactionTreeAsync(request);
+            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTreeAsync(r, co));
             return response.Transaction;
         }
 

--- a/src/Daml.Ledger.Client/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/CommandSubmissionClient.cs
@@ -7,18 +7,19 @@ namespace Daml.Ledger.Client
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Google.Protobuf.WellKnownTypes;
     using Grpc.Core;
 
     public class CommandSubmissionClient : ICommandSubmissionClient
     {
         private readonly string _ledgerId;
-        private readonly CommandSubmissionService.CommandSubmissionServiceClient _commandSubmissionClient;
+        private readonly ClientStub<CommandSubmissionService.CommandSubmissionServiceClient> _commandSubmissionClient;
 
         public CommandSubmissionClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _commandSubmissionClient = new CommandSubmissionService.CommandSubmissionServiceClient(channel);
+            _commandSubmissionClient = new ClientStub<CommandSubmissionService.CommandSubmissionServiceClient>(new CommandSubmissionService.CommandSubmissionServiceClient(channel));
         }
 
         public void Submit(
@@ -47,12 +48,12 @@ namespace Daml.Ledger.Client
 
         public void Submit(Commands commands)
         {
-            _commandSubmissionClient.Submit(new SubmitRequest { Commands = commands });
+            _commandSubmissionClient.Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.Submit(r, co));
         }
 
         public async Task SubmitAsync(Commands commands)
         {
-            await _commandSubmissionClient.SubmitAsync(new SubmitRequest { Commands = commands });
+            await _commandSubmissionClient.Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.SubmitAsync(r, co));
         }
 
         private Commands BuildCommands(

--- a/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
@@ -5,23 +5,24 @@ namespace Daml.Ledger.Client
 {
     using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class LedgerConfigurationClient : ILedgerConfigurationClient
     {
         private readonly string _ledgerId;
-        private readonly LedgerConfigurationService.LedgerConfigurationServiceClient _ledgerConfigurationClient;
+        private readonly ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient> _ledgerConfigurationClient;
 
         public LedgerConfigurationClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _ledgerConfigurationClient = new LedgerConfigurationService.LedgerConfigurationServiceClient(channel);
+            _ledgerConfigurationClient = new ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient>(new LedgerConfigurationService.LedgerConfigurationServiceClient(channel));
         }
 
         public IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(TraceContext traceContext = null)
         {
             var request = new GetLedgerConfigurationRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _ledgerConfigurationClient.GetLedgerConfiguration(request);
+            var response = _ledgerConfigurationClient.Dispatch(request, (c, r, co) => c.GetLedgerConfiguration(r, co));
             return response.ResponseStream;
         }
 

--- a/src/Daml.Ledger.Client/LedgerIdentityClient.cs
+++ b/src/Daml.Ledger.Client/LedgerIdentityClient.cs
@@ -5,26 +5,27 @@ namespace Daml.Ledger.Client
 {
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class LedgerIdentityClient : ILedgerIdentityClient
     {
-        private readonly LedgerIdentityService.LedgerIdentityServiceClient _ledgerIdentityClient;
+        private readonly ClientStub<LedgerIdentityService.LedgerIdentityServiceClient> _ledgerIdentityClient;
 
         public LedgerIdentityClient(Channel channel)
         {
-            _ledgerIdentityClient = new LedgerIdentityService.LedgerIdentityServiceClient(channel);
+            _ledgerIdentityClient = new ClientStub<LedgerIdentityService.LedgerIdentityServiceClient>(new LedgerIdentityService.LedgerIdentityServiceClient(channel));
         }
 
         public string GetLedgerIdentity()
         {
-            var response = _ledgerIdentityClient.GetLedgerIdentity(new GetLedgerIdentityRequest());
+            var response = _ledgerIdentityClient.Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentity(r, co));
             return response.LedgerId;
         }
 
         public async Task<string> GetLedgerIdentityAsync()
         {
-            var response = await _ledgerIdentityClient.GetLedgerIdentityAsync(new GetLedgerIdentityRequest());
+            var response = await _ledgerIdentityClient.Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentityAsync(r, co));
             return response.LedgerId;
         }
     }

--- a/src/Daml.Ledger.Client/PackageClient.cs
+++ b/src/Daml.Ledger.Client/PackageClient.cs
@@ -6,56 +6,57 @@ namespace Daml.Ledger.Client
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class PackageClient : IPackageClient
     {
         private readonly string _ledgerId;
-        private readonly PackageService.PackageServiceClient _packageClient;
+        private readonly ClientStub<PackageService.PackageServiceClient> _packageClient;
 
         public PackageClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _packageClient = new PackageService.PackageServiceClient(channel);
+            _packageClient = new ClientStub<PackageService.PackageServiceClient>(new PackageService.PackageServiceClient(channel));
         }
 
         public GetPackageResponse GetPackage(string packageId, TraceContext traceContext = null)
         {
             var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            return _packageClient.GetPackage(request);
+            return _packageClient.Dispatch(request, (c, r, co) => c.GetPackage(r, co));
         }
 
         public async Task<GetPackageResponse> GetPackageAsync(string packageId, TraceContext traceContext = null)
         {
             var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            return await _packageClient.GetPackageAsync(request);
+            return await _packageClient.Dispatch(request, (c, r, co) => c.GetPackageAsync(r, co));
         }
 
         public PackageStatus GetPackageStatus(string packageId, TraceContext traceContext = null)
         {
             var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            var response = _packageClient.GetPackageStatus(request);
+            var response = _packageClient.Dispatch(request, (c, r, co) => c.GetPackageStatus(r, co));
             return response.PackageStatus;
         }
 
         public async Task<PackageStatus> GetPackageStatusAsync(string packageId, TraceContext traceContext = null)
         {
             var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            var response = await _packageClient.GetPackageStatusAsync(request);
+            var response = await _packageClient.Dispatch(request, (c, r, co) => c.GetPackageStatusAsync(r, co));
             return response.PackageStatus;
         }
 
         public IEnumerable<string> ListPackages(TraceContext traceContext = null)
         {
             var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _packageClient.ListPackages(request);
+            var response = _packageClient.Dispatch(request, (c, r, co) => c.ListPackages(r, co));
             return response.PackageIds;
         }
 
         public async Task<IEnumerable<string>> ListPackagesAsync(TraceContext traceContext = null)
         {
             var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = await _packageClient.ListPackagesAsync(request);
+            var response = await _packageClient.Dispatch(request, (c, r, co) => c.ListPackagesAsync(r, co));
             return response.PackageIds;
         }
     }

--- a/src/Daml.Ledger.Client/Testing/ResetClient.cs
+++ b/src/Daml.Ledger.Client/Testing/ResetClient.cs
@@ -5,27 +5,28 @@ namespace Daml.Ledger.Client.Testing
 {
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Testing;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class ResetClient : IResetClient
     {
         private readonly string _ledgerId;
-        private readonly ResetService.ResetServiceClient _resetClient;
+        private readonly ClientStub<ResetService.ResetServiceClient> _resetClient;
 
         public ResetClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _resetClient = new ResetService.ResetServiceClient(channel);
+            _resetClient = new ClientStub<ResetService.ResetServiceClient>(new ResetService.ResetServiceClient(channel));
         }
 
         public void Reset()
         {
-            _resetClient.Reset(new ResetRequest { LedgerId = _ledgerId });
+            _resetClient.Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.Reset(r, co));
         }
 
         public async Task ResetAsync()
         {
-            await _resetClient.ResetAsync(new ResetRequest { LedgerId = _ledgerId });
+            await _resetClient.Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.ResetAsync(r, co));
         }
     }
 }

--- a/src/Daml.Ledger.Client/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client/TransactionsClient.cs
@@ -6,58 +6,59 @@ namespace Daml.Ledger.Client
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Client.Auth.Client;
     using Grpc.Core;
 
     public class TransactionsClient : ITransactionsClient
     {
         private readonly string _ledgerId;
-        private readonly TransactionService.TransactionServiceClient _transactionsClient;
+        private readonly ClientStub<TransactionService.TransactionServiceClient> _transactionsClient;
 
         public TransactionsClient(string ledgerId, Channel channel)
         {
             _ledgerId = ledgerId;
-            _transactionsClient = new TransactionService.TransactionServiceClient(channel);
+            _transactionsClient = new ClientStub<TransactionService.TransactionServiceClient>(new TransactionService.TransactionServiceClient(channel));
         }
 
         public GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.GetFlatTransactionByEventId(request);
+            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventId(r, co));
         }
 
         public async Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.GetFlatTransactionByEventIdAsync(request);
+            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventIdAsync(r, co));
         }
 
         public GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.GetFlatTransactionById(request);
+            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionById(r, co));
         }
 
         public async Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.GetFlatTransactionByIdAsync(request);
+            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByIdAsync(r, co));
         }
 
         public LedgerOffset GetLedgerEnd(TraceContext traceContext = null)
         {
             var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _transactionsClient.GetLedgerEnd(request);
+            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetLedgerEnd(r, co));
             return response.Offset;
         }
 
         public async Task<LedgerOffset> GetLedgerEndAsync(TraceContext traceContext = null)
         {
             var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = await _transactionsClient.GetLedgerEndAsync(request);
+            var response = await _transactionsClient.Dispatch(request, (c, r, co) => c.GetLedgerEndAsync(r, co));
             return response.Offset;
         }
 
@@ -65,28 +66,28 @@ namespace Daml.Ledger.Client
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.GetTransactionByEventId(request);
+            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByEventId(r, co));
         }
 
         public async Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.GetTransactionByEventIdAsync(request);
+            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByEventIdAsync(r, co));
         }
 
         public GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.GetTransactionById(request);
+            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionById(r, co));
         }
 
         public async Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.GetTransactionByIdAsync(request);
+            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByIdAsync(r, co));
         }
 
         public IAsyncEnumerator<GetTransactionsResponse> GetTransactions(
@@ -105,7 +106,7 @@ namespace Daml.Ledger.Client
                     Verbose = verbose,
                     TraceContext = traceContext
                 };
-            var response = _transactionsClient.GetTransactions(request);
+            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactions(r, co));
             return response.ResponseStream;
         }
 
@@ -141,7 +142,7 @@ namespace Daml.Ledger.Client
                     Verbose = verbose,
                     TraceContext = traceContext
                 };
-            var response = _transactionsClient.GetTransactionTrees(request);
+            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionTrees(r, co));
             return response.ResponseStream;
         }
 


### PR DESCRIPTION
Wrapped all gRPC ServiceClient instances with an instance of the new ClientStub class which will allow me to add access tokens at construction and also service method call time. 

The ClientStub class has a Dispatch method which constructs the relevant CallOptions object according to whether or not there is an access token and then passes it to the supplied functor to pass to the actual service client method - which also allows setting of all of the extra call parameters on the service method via the CallOptions builder interface - see the comments in the ClientStub class