### PR TITLE
Accesstokens

### DIFF
--- a/Daml.Ledger.Builder.csproj
+++ b/Daml.Ledger.Builder.csproj
@@ -1,9 +1,16 @@
-﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="AutoBuild">
-  
+﻿<Project ToolsVersion="4.0" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="AutoBuild">
+
   <Target Name="Build" DependsOnTargets="AutoBuild">
   </Target>
 
-  <Target Name="AutoBuild" DependsOnTargets="ClientTest;ReactiveTest;Automation;BindingsExample;TestExample">
+  <Target Name="AutoBuild" DependsOnTargets="Reactive;Automation;Tests;Examples">
+  </Target>
+
+  <Target Name="Tests" DependsOnTargets="ClientTest;ApiDataTest;ReactiveTest">
+  </Target>
+
+  <Target Name="Examples" DependsOnTargets="BindingsExample;TestExample">
   </Target>
 
   <Target Name="Api">
@@ -34,7 +41,21 @@
     <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
   </Target>
 
-  <Target Name="Reactive" DependsOnTargets="Client">
+  <Target Name="ApiData" DependsOnTargets="Api">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Api.Data</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="ApiDataTest" DependsOnTargets="ApiData">
+    <PropertyGroup>
+      <Project>Daml.Ledger.Api.Data.Test</Project>
+    </PropertyGroup>
+    <Exec Command="dotnet build -c $(Configuration) ./src/$(Project)/$(Project).csproj" />
+  </Target>
+
+  <Target Name="Reactive" DependsOnTargets="Client;ApiData">
     <PropertyGroup>
       <Project>Daml.Ledger.Client.Reactive</Project>
     </PropertyGroup>

--- a/Daml.Ledger.sln
+++ b/Daml.Ledger.sln
@@ -39,6 +39,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Examples.Bindin
 		{68C093F1-5FA2-4DA9-8A84-50782FAAF022} = {68C093F1-5FA2-4DA9-8A84-50782FAAF022}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Api.Data", "src\Daml.Ledger.Api.Data\Daml.Ledger.Api.Data.csproj", "{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1} = {F33AA8C5-B9B8-4FBE-A38C-AE204A130BF1}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Api.Data.Test", "src\Daml.Ledger.Api.Data.Test\Daml.Ledger.Api.Data.Test.csproj", "{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30} = {C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Daml.Ledger.Client.Reactive.Test", "src\Daml.Ledger.Client.Reactive.Test\Daml.Ledger.Client.Reactive.Test.csproj", "{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}"
 	ProjectSection(ProjectDependencies) = postProject
 		{C28365C5-6F64-4468-8FFC-93121553C2EA} = {C28365C5-6F64-4468-8FFC-93121553C2EA}
@@ -143,6 +153,30 @@ Global
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
 		{8D7F5468-46FB-4D71-924F-7F0B7108FF58}.ReleaseNuget|x86.Build.0 = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Debug|x86.Build.0 = Debug|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Release|x86.ActiveCfg = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.Release|x86.Build.0 = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{C3FA1505-EF77-4192-AFE1-C93AD7EC3C30}.ReleaseNuget|x86.Build.0 = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Debug|x86.Build.0 = Debug|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Release|x86.ActiveCfg = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.Release|x86.Build.0 = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.ReleaseNuget|Any CPU.ActiveCfg = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.ReleaseNuget|Any CPU.Build.0 = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.ReleaseNuget|x86.ActiveCfg = Release|Any CPU
+		{5279BDAB-EC1C-4A6A-A0E9-9431B890CB51}.ReleaseNuget|x86.Build.0 = Release|Any CPU
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA9DEA91-F0A7-4A68-B4A3-730F6CC5BDF6}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/src/Daml.Ledger.Api.Data.Test/Daml.Ledger.Api.Data.Test.csproj
+++ b/src/Daml.Ledger.Api.Data.Test/Daml.Ledger.Api.Data.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <RootNamespace>Daml.Ledger.Client.Test</RootNamespace>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Daml.Ledger.Api.Data.Test</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -18,13 +18,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Folder Include="Admin\" />
+    <Folder Include="Auth\" />
+    <Folder Include="Testing\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" />
+    <ProjectReference Include="..\Daml.Ledger.Api.Data\Daml.Ledger.Api.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Daml.Ledger.Api.Data.Test/util/OptionalExtensionsTest.cs
+++ b/src/Daml.Ledger.Api.Data.Test/util/OptionalExtensionsTest.cs
@@ -1,0 +1,148 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using Daml.Ledger.Api.Data.Util;
+using NUnit.Framework;
+
+namespace Daml.Ledger.Api.Data.Util.Test
+{
+    /// <summary>
+    /// These 'tests' just demonstrate the examples at http://codinghelmet.com/articles/custom-implementation-of-the-option-maybe-type-in-cs
+    /// </summary>
+    [TestFixture]
+    public class OptionalExtensionsTest
+    {
+        private class Person
+        {
+            private readonly int _age;
+            private readonly Color _carColor;
+
+            public Person(string name, int age, Color carColor)
+            {
+                Name = name;
+                _age = age;
+                _carColor = carColor;
+            }
+
+            public Optional<Car> TryGetCar()
+            {
+                if (_age >= 18)
+                    return new Car("honda", _carColor);
+                return None.Value;
+            }
+
+            public string Name { get; }
+        }
+
+        [Test]
+        public void WillSetSomeIfNotNull()
+        {
+            Car car = new Car("honda", Color.Aqua);
+
+            Optional<Car> maybeCar = car.NoneIfNull();
+
+            Assert.AreEqual(typeof(Some<Car>), maybeCar.GetType());
+        }
+
+        [Test]
+        public void WillSetNoneIfNull()
+        {
+            Car car = null;
+
+            Optional<Car> maybeCar = car.NoneIfNull();
+
+            Assert.AreEqual(typeof(None<Car>), maybeCar.GetType());
+        }
+
+        [Test]
+        public void WhenSetsSomeWhenContentMatched()
+        {
+            var color = Color.Cyan;
+            Optional<Color> maybeColor1 = color.When(color == Color.Cyan);
+            Assert.AreEqual(typeof(Some<Color>), maybeColor1.GetType());
+
+            Optional<Color> maybeColor2 = color.When(c => c == Color.Cyan);
+            Assert.AreEqual(typeof(Some<Color>), maybeColor2.GetType());
+        }
+
+        [Test]
+        public void WhenSetsNoneIfContentNotMatched()
+        {
+            var color = Color.Cyan;
+            Optional<Color> maybeColor1 = color.When(color == Color.Red);
+            Assert.AreEqual(typeof(None<Color>), maybeColor1.GetType());
+
+            Optional<Color> maybeColor2 = color.When(c => c == Color.Red);
+            Assert.AreEqual(typeof(None<Color>), maybeColor2.GetType());
+        }
+
+        [Test]
+        public void FirstOrNoneGetsNoneForEmptySequence()
+        {
+            IEnumerable<Color> colors = new Color[0];
+
+            Optional<Color> maybeColor = colors.FirstOrNone();
+            Assert.AreEqual(typeof(None<Color>), maybeColor.GetType());
+        }
+
+        [Test]
+        public void FirstOrNoneGetSomeForSequence()
+        {
+            IEnumerable<Color> colors = new[] { Color.Red, Color.Blue};
+
+            Optional<Color> maybeColor = colors.FirstOrNone();
+            Assert.AreEqual(typeof(Some<Color>), maybeColor.GetType());
+            Assert.AreEqual(Color.Red, maybeColor.Reduce(Color.AliceBlue));
+        }
+
+        [Test]
+        public void FirstOrNoneGetNoneForSequenceIfPredicateNotMatched()
+        {
+            IEnumerable<Color> colors = new[] { Color.Red, Color.Blue };
+
+            Optional<Color> maybeColor = colors.FirstOrNone(c => c == Color.Green);
+            Assert.AreEqual(typeof(None<Color>), maybeColor.GetType());
+        }
+
+        [Test]
+        public void CanGetFilteredOptionalSequence()
+        {
+            IEnumerable<Person> people = new[]
+            {
+                new Person("Jack", 9, Color.Green), // No car
+                new Person("Jill", 19, Color.Red),  // Has a red car
+                new Person("Joe", 22, Color.Blue)  // Has a blue car
+            };
+
+            IEnumerable<Color> colors = people.SelectOptional(p => p.TryGetCar()).Select(c => c.Color);
+            Assert.AreEqual(2, colors.Count());
+
+            var temp = colors.ToArray();
+            Assert.AreEqual(Color.Red, temp[0]);
+            Assert.AreEqual(Color.Blue, temp[1]);
+        }
+
+        [Test]
+        public void CanGetOptionalFromDictionary()
+        {
+            IEnumerable<Person> people = new[]
+            {
+                new Person("Jack", 9, Color.Green), // No car
+                new Person("Jill", 19, Color.Red),  // Has a red car
+                new Person("Joe", 22, Color.Blue)   // Has a blue car
+            };
+
+            Dictionary<string, Car> dict = people.SelectOptional(p => p.TryGetCar().Map(car => (name: p.Name, car: car))).ToDictionary(tuple => tuple.name, tuple => tuple.car);
+
+            Optional<Car> jillsCar = dict.TryGetValue("Jill");
+            Assert.AreEqual(typeof(Some<Car>), jillsCar.GetType());
+            Assert.AreEqual(Color.Red, jillsCar.Map(c => c.Color).Reduce(Color.Black));
+
+            Optional<Car> tomsCar = dict.TryGetValue("Tom");
+            Assert.AreEqual(typeof(None<Car>), tomsCar.GetType());
+        }
+    }
+}

--- a/src/Daml.Ledger.Api.Data.Test/util/OptionalTest.cs
+++ b/src/Daml.Ledger.Api.Data.Test/util/OptionalTest.cs
@@ -1,0 +1,218 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Drawing;
+using NUnit.Framework;
+
+namespace Daml.Ledger.Api.Data.Util.Test
+{
+    /// <summary>
+    /// These 'tests' just demonstrate the examples at http://codinghelmet.com/articles/custom-implementation-of-the-option-maybe-type-in-cs
+    /// </summary>
+    [TestFixture]
+    public class OptionalTest
+    {
+        private readonly Person _youngPerson = new Person(new DateTime(2010, 2, 20));
+        private readonly Person _olderPerson = new Person(new DateTime(1990, 2, 20));
+        private readonly DateTime _now = new DateTime(2019, 2, 20);
+
+        private class Person
+        {
+            public DateTime BirthDate { get; }
+
+            public Person(DateTime birthDate)
+            {
+                BirthDate = birthDate.Date;
+            }
+
+            public Optional<Car> TryGetCar(DateTime at)
+            {
+                if (BirthDate.AddYears(18) <= at)
+                    return new Car("honda", Color.Aqua);
+                return None.Value;
+            }
+        }
+
+        [Test]
+        public void CanCreateSomeWithOf()
+        {
+            var maybePerson = Optional.Of(_youngPerson);
+            Assert.AreEqual(typeof(Some<Person>), maybePerson.GetType());
+            Assert.IsTrue(maybePerson.IsPresent);
+            bool set = false;
+            maybePerson.IfPresent(p => set = true);
+            Assert.IsTrue(set);
+        }
+
+        [Test]
+        public void OfThrowsForNull()
+        {
+            Person nobody = null;
+            Assert.Throws<NullReferenceException>(() => Optional.Of(nobody));
+        }
+
+        [Test]
+        public void OfNullableCreatesNoneForNull()
+        {
+            Person nobody = null;
+            var maybePerson = Optional.OfNullable(nobody);
+            Assert.AreEqual(typeof(None<Person>), maybePerson.GetType());
+            Assert.IsFalse(maybePerson.IsPresent);
+            bool set = false;
+            maybePerson.IfPresent(p => set = true);
+            Assert.IsFalse(set);
+        }
+
+        [Test]
+        public void CanMapNoneOptional()
+        {
+            Optional<Car> maybeCar = _youngPerson.TryGetCar(_now);
+
+            Assert.AreEqual(typeof(None<Car>), maybeCar.GetType());
+        }
+
+        [Test]
+        public void CanMapSomeOptional()
+        {
+            Optional<Car> maybeCar = _olderPerson.TryGetCar(_now);
+
+            Assert.AreEqual(typeof(Some<Car>), maybeCar.GetType());
+        }
+
+        [Test]
+        public void CanMapNoneOptionalFromOptional()
+        {
+            Optional<Color> maybeColor = _youngPerson.TryGetCar(_now).Map(c => c.Color);
+
+            Assert.AreEqual(typeof(None<Color>), maybeColor.GetType());
+        }
+
+        [Test]
+        public void CanMapSomeOptionalFromOptional()
+        {
+            Optional<Color> maybeColor = _olderPerson.TryGetCar(_now).Map(c => c.Color);
+
+            Assert.AreEqual(typeof(Some<Color>), maybeColor.GetType());
+        }
+
+        [Test]
+        public void NoneOptionalChainsThroughNoneOptional()
+        {
+            Optional<Person> somePerson = _youngPerson;
+
+            Optional<Color> maybeColor = somePerson.Map(person => person.TryGetCar(_now)).Map(c => c.Color);
+
+            Assert.AreEqual(typeof(None<Color>), maybeColor.GetType(), "Shouldn't have got color as no car");
+        }
+
+        [Test]
+        public void SomeOptionalChainsThroughSomeOptional()
+        {
+            Optional<Person> somePerson = _olderPerson;
+
+            Optional<Color> maybeColor = somePerson.Map(person => person.TryGetCar(_now)).Map(c => c.Color);
+
+            Assert.AreEqual(typeof(Some<Color>), maybeColor.GetType(), "Should have got color as some car");
+        }
+
+        [Test]
+        public void InitialNoneResultsInNoneOptional()
+        {
+            Optional<Person> somePerson = None.Value;
+
+            Optional<Color> maybeColor = somePerson.Map(person => person.TryGetCar(_now)).Map(c => c.Color);
+
+            Assert.AreEqual(typeof(None<Color>), maybeColor.GetType(), "Shouldn't have got color as no person");
+        }
+
+        [Test]
+        public void CanRetrieveValueOfSomeOptional()
+        {
+            Color color = _olderPerson.TryGetCar(_now).Map(c => c.Color).Reduce(Color.Black);
+
+            Assert.AreEqual(Color.Aqua, color, "Should have got color as some car");
+        }
+
+        [Test]
+        public void CanRetrieveValueOfSomeOptionalWithLambda()
+        {
+            Color color = _olderPerson.TryGetCar(_now).Map(c => c.Color).Reduce(() => Color.Black);
+
+            Assert.AreEqual(Color.Aqua, color, "Should have got color as some car");
+        }
+
+        [Test]
+        public void CanRetrieveValueOfNoneOptional()
+        {
+            Color color = _youngPerson.TryGetCar(_now).Map(c => c.Color).Reduce(Color.Black);
+
+            Assert.AreEqual(Color.Black, color);
+        }
+
+        [Test]
+        public void CanRetrieveValueOfNoneOptionalWithLambda()
+        {
+            Color color = _youngPerson.TryGetCar(_now).Map(c => c.Color).Reduce(() => Color.Black);
+
+            Assert.AreEqual(Color.Black, color);
+        }
+
+        [Test]
+        public void CanCastOptionalToType()
+        {
+            Optional<Car> someCar = new Car("car", Color.Red);
+            Optional<Car> noCar = None.Value;
+
+            Optional<Vehicle> someVehicle = someCar.OfType<Vehicle>();
+            Assert.AreEqual(typeof(Some<Vehicle>), someVehicle.GetType());
+
+            Optional<Vehicle> noVehicle = noCar.OfType<Vehicle>();
+            Assert.AreEqual(typeof(None<Vehicle>), noVehicle.GetType());
+
+            Optional<Truck> noTruck = someCar.OfType<Truck>();
+            Assert.AreEqual(typeof(None<Truck>), noTruck.GetType());
+        }
+
+        [Test]
+        public void CanTestForEquality()
+        {
+            Optional<Color> red = Color.Red;
+            Optional<Color> otherRed = Color.Red;
+            Optional<Color> blue = Color.Blue;
+
+            Assert.IsTrue(red.GetHashCode() == otherRed.GetHashCode());
+
+            Assert.IsTrue(red.Equals(otherRed));
+            Assert.IsTrue(red == otherRed);
+            Assert.IsFalse(red != otherRed);
+
+            Assert.IsFalse(red.Equals(Color.Red));
+            Assert.IsFalse(Color.Red.Equals(red));
+            Assert.IsFalse(red.Equals(blue));
+            Assert.IsFalse(red == blue);
+            Assert.IsTrue(red != blue);
+
+            Optional<Color> none = None.Value;
+            Optional<Color> otherNone = None.Value;
+
+            Assert.IsTrue(none.Equals(otherNone));
+            Assert.IsTrue(none == otherNone);
+            Assert.IsFalse(none != otherNone);
+            Assert.IsTrue(none.Equals(None.Value));
+            Assert.IsTrue(None.Value.Equals(none));
+        }
+
+        [Test]
+        public void CanFilterOptional()
+        {
+            var maybePerson = Optional.Of(_youngPerson);
+
+            var maybeYoungPerson = maybePerson.Filter(p => p.BirthDate.Year == 2010);
+            Assert.AreEqual(typeof(Some<Person>), maybeYoungPerson.GetType());
+
+            var maybeOlderPerson = maybePerson.Filter(p => p.BirthDate.Year == 1990);
+            Assert.AreEqual(typeof(None<Person>), maybeOlderPerson.GetType());
+        }
+    }
+}

--- a/src/Daml.Ledger.Api.Data.Test/util/SingleTest.cs
+++ b/src/Daml.Ledger.Api.Data.Test/util/SingleTest.cs
@@ -1,0 +1,180 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Daml.Ledger.Api.Data.Util.Test
+{
+    [TestFixture]
+    public class SingleTest
+    {
+        [Test]
+        public void CanCreateSingleForImmediateValue()
+        {
+            var single = Single.Just(5);
+
+            Assert.AreEqual(5, single.Result);
+
+            int notificationCount = 0;
+            int errorCount = 0;
+            int values = 0;
+
+            using (var subscription = single.Subscribe(v => { ++notificationCount; values += v; }, e => ++errorCount))
+            { }
+
+            using (var subscription = single.Subscribe(v => { ++notificationCount; values += v; }, e => ++errorCount))
+            { }
+
+            Assert.AreEqual(2, notificationCount);
+            Assert.AreEqual(0, errorCount);
+            Assert.AreEqual(10, values);
+        }
+
+        [Test]
+        public void CanCreateFailedSingle()
+        {
+            var exception = new Exception("failed");
+
+            var single = Single.Error<int>(exception);
+
+            int notificationCount = 0;
+
+            var errors = new List<Exception>();
+
+            using (var subscription = single.Subscribe(v => ++notificationCount, e => errors.Add(e)))
+            { }
+
+            using (var subscription = single.Subscribe(v => ++notificationCount, e => errors.Add(e)))
+            { }
+
+            Assert.AreEqual(0, notificationCount);
+            Assert.AreEqual(2, errors.Count);
+            Assert.AreEqual(exception, errors[0]);
+            Assert.AreEqual(exception, errors[1]);
+        }
+
+        [Test]
+        public void AccessingResultForFailedSingleResultsInException()
+        {
+            var single = Single.Error<int>(new Exception("failed"));
+
+            try
+            {
+                int val = single.Result;
+
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual("One or more errors occurred. (failed)", e.Message);
+            }
+        }
+        
+        [Test]
+        public void CanCreateSingleFromCompletedTask()
+        {
+            var single = Single.Just(Task.FromResult(5));
+
+            Assert.AreEqual(5, single.Result);
+        }
+
+        [Test]
+        public void WillBlockOnResultOfAsyncTask()
+        {
+            int millisDelay = 2000;
+
+            Task<int> task = new Task<int>(() => { Thread.Sleep(millisDelay); return 5; });
+
+            var single = Single.Just(task);
+
+            Stopwatch timer = new Stopwatch();
+
+            timer.Start();
+            task.Start();
+
+            int val = single.Result;
+
+            timer.Stop();
+
+            Assert.AreEqual(5, val);
+
+            Assert.AreEqual(millisDelay, timer.ElapsedMilliseconds, 20, "Blocking delay different then expected");
+        }
+
+        [Test]
+        public void IsNotifiedByAsyncTask()
+        {
+            int millisDelay = 2000;
+
+            Task<int> task = new Task<int>(() => { Thread.Sleep(millisDelay); return 5; });
+
+            var single = Single.Just(task);
+
+            DateTime notificationTime = DateTime.MinValue;
+            Exception notifiedException = null;
+
+            using (var subscription = single.Subscribe(v =>  notificationTime = DateTime.UtcNow, e => { notifiedException = e; }))
+            {
+                DateTime startTime = DateTime.UtcNow;
+
+                task.Start();
+
+                // Block until we are notified which might be after the single is completed because of 'asynchronicity'!
+                while (notificationTime == DateTime.MinValue)
+                {
+                    Thread.Sleep(500);
+                    if ((DateTime.UtcNow - startTime).TotalSeconds > 10)    // Just in case
+                        break;
+                }
+
+                var notificationDelay = (notificationTime - startTime).TotalMilliseconds;
+
+                Assert.IsNull(notifiedException);
+                Assert.AreEqual(millisDelay, notificationDelay, 20, $"Notification delay different then expected : got {notificationDelay} : expected {millisDelay}");
+            }
+        }
+
+        [Test]
+        public void CancellingAsyncTaskThrowsErrorToObserver()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Task<int> task = new Task<int>(() =>
+            {
+                Thread.Sleep(20000);
+                return 5;
+            }, cancellationTokenSource.Token);
+
+            var single = Single.Just(task);
+
+            DateTime notificationTime = DateTime.MinValue;
+            Exception notifiedException = null;
+
+            using (var subscription = single.Subscribe(v => notificationTime = DateTime.UtcNow, e => { notifiedException = e; }))
+            {
+                DateTime startTime = DateTime.UtcNow;
+
+                task.Start();
+
+                cancellationTokenSource.Cancel();
+
+                // Block until we are notified which might be after the single is completed because of 'asynchronicity'!
+                while (notificationTime == DateTime.MinValue && notifiedException == null)
+                {
+                    Thread.Sleep(500);
+                    if ((DateTime.UtcNow - startTime).TotalSeconds > 10)    // Just in case
+                        break;
+                }
+
+                Assert.AreEqual(DateTime.MinValue, notificationTime, "Have been notified after cancellation");
+                Assert.IsNotNull(notifiedException, "Exception not notified");
+                Assert.AreEqual("A task was canceled.", notifiedException.Message);
+            }
+        }
+
+    }
+}

--- a/src/Daml.Ledger.Api.Data.Test/util/Vehicles.cs
+++ b/src/Daml.Ledger.Api.Data.Test/util/Vehicles.cs
@@ -1,0 +1,36 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Drawing;
+
+namespace Daml.Ledger.Api.Data.Util.Test
+{
+    public abstract class Vehicle
+    {
+        public Vehicle(string name, Color color)
+        {
+            Name = name;
+            Color = color;
+        }
+
+        public string Name { get; }
+        public Color Color { get; }
+    }
+
+    public class Car : Vehicle
+    {
+        public Car(string name, Color color)
+         :base(name, color)
+        { 
+        }
+    }
+
+    public class Truck : Vehicle
+    {
+        public Truck(string name, Color color)
+            : base(name, color)
+        {
+        }
+    }
+
+}

--- a/src/Daml.Ledger.Api.Data/Daml.Ledger.Api.Data.csproj
+++ b/src/Daml.Ledger.Api.Data/Daml.Ledger.Api.Data.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Daml.Ledger.Client.Reactive</RootNamespace>
+    <RootNamespace>Daml.Ledger.Api.Data</RootNamespace>
     <Configuration>Release</Configuration>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'ReleaseNuget'">
-    <PackageId>Daml.Ledger.Client.Reactive</PackageId>
-    <PackageTags>.net C# daml ledger Rx.Net api</PackageTags>
-    <Product>net reactive bindings</Product>
+    <PackageId>Daml.Ledger.Api.Data</PackageId>
+    <PackageTags>.NET C# DAML Ledger Api Data</PackageTags>
+    <Product>DAML .NET Ledger Api Data</Product>
     <Authors>Georg Schneider</Authors>
     <Company>Digital Asset</Company>
     <AssemblyVersion>$(Version)</AssemblyVersion>
@@ -29,30 +29,34 @@
     <NoWarn></NoWarn>
     <NoStdLib>false</NoStdLib>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Admin\" />
+    <Folder Include="Auth\" />
+    <Folder Include="Testing\" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.5" />
-    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 
   <Choose>
     <When Condition="'$(Configuration)' == 'ReleaseNuget'">
       <ItemGroup>
-        <PackageReference Include="Daml.Ledger.Client" Version="$(Version)" />
-        <PackageReference Include="Daml.Ledger.Api.Data" Version="$(Version)" />
-        <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
-        <ProjectReference Include="..\Daml.Ledger.Api.Data\Daml.Ledger.Api.Data.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+        <PackageReference Include="Daml.Ledger.Api" Version="$(Version)" />
+        <ProjectReference Include="..\Daml.Ledger.Api\Daml.Ledger.Api.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <ProjectReference Include="..\Daml.Ledger.Client\Daml.Ledger.Client.csproj" />
-        <ProjectReference Include="..\Daml.Ledger.Api.Data\Daml.Ledger.Api.Data.csproj" />
+        <ProjectReference Include="..\Daml.Ledger.Api\Daml.Ledger.Api.csproj" />
       </ItemGroup>
     </Otherwise>
   </Choose>
 
-  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack"> 
+  <Target Name="InstallPackage" Condition="'$(Configuration)' == 'ReleaseNuget'" AfterTargets="Pack">
     <Exec Command="nuget install $(PackageId) -Version $(Version) -OutputDirectory $(PackageOutputPath)" />
   </Target>
 
 </Project>
+

--- a/src/Daml.Ledger.Api.Data/util/None.cs
+++ b/src/Daml.Ledger.Api.Data/util/None.cs
@@ -1,0 +1,62 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace Daml.Ledger.Api.Data.Util
+{
+    /// <summary>
+    /// An Optional wrapper for no value, or None.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class None<T> : Optional<T>, IEquatable<None<T>>, IEquatable<None>
+    {
+        // A None will always map to a None so don't bother calling the mapping function
+        public override Optional<TResult> Map<TResult>(Func<T, TResult> map) => None.Value;
+
+        // A None will always map to an implicitly converted Optional<None> so don't bother calling the mapping function
+        public override Optional<TResult> Map<TResult>(Func<T, Optional<TResult>> map) => None.Value;
+
+        public override TResult MapOrElse<TResult>(Func<T, TResult> map, Func<TResult> whenNone) => whenNone();
+
+        // Return None 
+        public override Optional<T> Filter(Func<T, bool> predicate) => None.Value;
+
+        // No value so return default value
+        public override T Reduce(T whenNone) => whenNone;
+
+        // No value so call function to get default value
+        public override T Reduce(Func<T> whenNone) => whenNone();
+
+        public override bool Equals(object obj) => !(obj is null) && (obj is None<T> || obj is None);
+
+        public override int GetHashCode() => 0;
+
+        public bool Equals(None<T> other) => true;
+
+        public bool Equals(None other) => true;
+
+        public override string ToString() => "None";
+
+        public override bool IsPresent => false;
+
+        // Never present so don't call the action
+        public override void IfPresent(Action<T> action) { }
+    }
+
+    public sealed class None
+    {
+        public static None Value { get; } = new None();
+        private None() { }
+
+        public override bool Equals(object obj) => !(obj is null) && (obj is None || IsGenericNone(obj.GetType()));
+
+        private bool IsGenericNone(Type type) => type.GenericTypeArguments.Length == 1 && typeof(None<>).MakeGenericType(type.GenericTypeArguments[0]) == type;
+
+        public bool Equals(None other) => true;
+
+        public override int GetHashCode() => 0;
+
+        public override string ToString() => "None";
+    }
+}

--- a/src/Daml.Ledger.Api.Data/util/Optional.cs
+++ b/src/Daml.Ledger.Api.Data/util/Optional.cs
@@ -1,0 +1,87 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace Daml.Ledger.Api.Data.Util
+{
+#pragma warning disable CS0660  // Use the derived class Equals and GetHashCode
+#pragma warning disable CS0661 
+
+    /// <summary>
+    /// Class to map an optional value. For example - a person may or may not have a Car - they have an Optional Car...
+    /// If they have a car - it is Some Car, whereas if they don't it is None Car - or just None.
+    /// See http://codinghelmet.com/articles/custom-implementation-of-the-option-maybe-type-in-cs
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public abstract class Optional<T>
+    {
+        // Implicit conversions to convert to a Some or a None
+
+        public static implicit operator Optional<T>(T value) => new Some<T>(value);
+        public static implicit operator Optional<T>(None none) => new None<T>();
+
+        // Map the wrapped value to an Optional of another type using the specified mapping function which returns the value as a new type
+        public abstract Optional<TResult> Map<TResult>(Func<T, TResult> map);
+
+        // Overload to catch where the mapping function already returns an Optional, matching the type - otherwise the other version will return an Optional<Optional<TResult>>.
+        // Renamed to match the Java version
+        public abstract Optional<TResult> Map<TResult>(Func<T, Optional<TResult>> map);
+
+        // Map the wrapped value to an Optional of another type using the specified mapping function which returns the value as a new type, or if the Optional is None
+        public abstract TResult MapOrElse<TResult>(Func<T, TResult> map, Func<TResult> whenNone);
+
+        // Return the existing Optional if the predicate returns true, otherwise None. If the value is None then None is returned
+        public abstract Optional<T> Filter(Func<T, bool> predicate);
+
+        // Extract the contained value, or the specified value if None
+        public abstract T Reduce(T whenNone);
+
+        // Extract the contained value, or the specified function return value if None - allow a lazy-evaluation lambda to be specified to get the value
+        public abstract T Reduce(Func<T> whenNone);
+
+        // Convert the wrapped value to the new type if possible, if not or the types are convertable then the returned value will be None
+        public Optional<TNew> OfType<TNew>() where TNew : class => this is Some<T> some && typeof(TNew).IsAssignableFrom(typeof(T))
+            ? (Optional<TNew>)new Some<TNew>(some.Content as TNew) : None.Value;
+
+        // Will use the overriden Equals in the derived class
+        public static bool operator ==(Optional<T> a, Optional<T> b) => ReferenceEquals(a, b) || (!(a is null) && a.Equals(b));
+
+        public static bool operator !=(Optional<T> a, Optional<T> b) => !(a == b);
+
+        // Some methods to mimic the Java interface for Optional to ease porting from Java
+
+        public abstract bool IsPresent { get; }
+
+        // Perform an action if Some
+        public abstract void IfPresent(Action<T> action);
+    }
+
+#pragma warning restore CS0661
+#pragma warning restore CS0660
+
+    // Java-like factory method
+    public static class Optional
+    {
+        public static Optional<T> Of<T>(T value)
+        {
+            if (value == null)
+                throw new NullReferenceException("Optional value should not be null");
+            return new Some<T>(value);
+        }
+
+        public static Optional<T> OfNullable<T>(T value)
+        {
+            if (value == null)
+                return None.Value;
+            return new Some<T>(value);
+        }
+
+        public static Optional<string> OfNullable(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return None.Value;
+            return new Some<string>(value);
+        }
+    }
+}

--- a/src/Daml.Ledger.Api.Data/util/OptionalExtensions.cs
+++ b/src/Daml.Ledger.Api.Data/util/OptionalExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Daml.Ledger.Api.Data.Util
+{
+    public static class OptionalExtensions
+    {
+        public static Optional<T> When<T>(this T obj, bool condition) => condition ? (Optional<T>)new Some<T>(obj) : None.Value;
+
+        public static Optional<T> When<T>(this T obj, Func<T, bool> predicate) => obj.When(predicate(obj));
+
+        public static Optional<T> NoneIfNull<T>(this T obj) => obj.When(!object.ReferenceEquals(obj, null));
+
+        public static Optional<T> FirstOrNone<T>(this IEnumerable<T> sequence) => sequence.Select(x => (Optional<T>)new Some<T>(x)).DefaultIfEmpty(None.Value).First();
+
+        public static Optional<T> FirstOrNone<T>(this IEnumerable<T> sequence, Func<T, bool> predicate) => sequence.Where(predicate).FirstOrNone();
+
+        // Apply a function returning an Optional to each member of a sequence and then return a sequence without any None items 
+        public static IEnumerable<TResult> SelectOptional<T, TResult>(this IEnumerable<T> sequence, Func<T, Optional<TResult>> map)
+        {
+            return sequence.Select(map).OfType<Some<TResult>>().Select(some => some.Content);
+        }
+
+        // Return a Some optional if the dictionary contains a key, else None
+        public static Optional<TValue> TryGetValue<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.TryGetValue(key, out TValue value) ? (Optional<TValue>) new Some<TValue>(value) : None.Value;
+        }
+    }
+}

--- a/src/Daml.Ledger.Api.Data/util/Single.cs
+++ b/src/Daml.Ledger.Api.Data/util/Single.cs
@@ -1,0 +1,120 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+
+namespace Daml.Ledger.Api.Data.Util
+{
+    public interface ISingleObserver<T>
+    {
+        void OnSuccess(T value);
+        void OnError(Exception error);
+    }
+
+    public interface ISingleSource<T>
+    {
+        IDisposable Subscribe(ISingleObserver<T> observer);
+    }
+
+    /// <summary>
+    /// Represents a single observable value. Whereas the Java version has tons of methods similar to Observable, this version
+    /// has a minimal set and it should be converted to an Observable in order to do anything more sophisticated.
+    /// The Result property will block until completion, as for a Task.
+    ///
+    /// See http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class Single<T> : ISingleSource<T>
+    {
+        private readonly IObservable<T> _impl;
+
+        /// <summary>
+        /// Initialise with a value so this is immediately completed
+        /// </summary>
+        /// <param name="value"></param>
+        public Single(T value)
+        {
+            var asyncSubject = new AsyncSubject<T>();
+            _impl = asyncSubject;
+            asyncSubject.OnNext(value);
+            asyncSubject.OnCompleted();
+        }
+
+        /// <summary>
+        /// Initialise with a Task that may not yet be complete
+        /// </summary>
+        /// <param name="task"></param>
+        public Single(Task<T> task)
+        {
+            _impl = task.ToObservable();
+        }
+
+        /// <summary>
+        ///  Initialise with an error to provide the observer 
+        /// </summary>
+        /// <param name="error"></param>
+        public Single(Exception error)
+        {
+            var asyncSubject = new AsyncSubject<T>();
+            _impl = asyncSubject;
+            asyncSubject.OnError(error);
+        }
+
+        public IDisposable Subscribe(ISingleObserver<T> singleObserver) => _impl.Subscribe(new SingleObserverShim(singleObserver));
+
+        /// <summary>
+        ///  Block on the result if not completed
+        /// </summary>
+        public T Result => _impl.ToTask().Result;
+
+        /// <summary>
+        /// Return this as an Observable
+        /// </summary>
+        /// <returns></returns>
+        public IObservable<T> ToObservable() => _impl;
+
+        // Shim the notifications from the AsyncSubject or Task-based Observable to the SingleObserver
+        private class SingleObserverShim : IObserver<T>
+        {
+            private readonly ISingleObserver<T> _singleObserver;
+
+            public SingleObserverShim(ISingleObserver<T> singleObserver) { _singleObserver = singleObserver; }
+
+            void IObserver<T>.OnCompleted() { }
+            void IObserver<T>.OnError(Exception error) => _singleObserver.OnError(error);
+            void IObserver<T>.OnNext(T value) => _singleObserver.OnSuccess(value);
+        }
+    }
+
+    public static class Single
+    {
+        public static Single<T> Just<T>(T value) => new Single<T>(value);
+
+        public static Single<T> Just<T>(Task<T> value) => new Single<T>(value);
+
+        public static Single<T> AsSingle<T>(this Task<T> task) => new Single<T>(task);
+        public static Single<T> Error<T>(Exception error) => new Single<T>(error);
+
+        public static IDisposable Subscribe<T>(this Single<T> single, Action<T> onSuccess) => single.Subscribe(new SingleObserver<T>(onSuccess, null));
+        public static IDisposable Subscribe<T>(this Single<T> single, Action<T> onSuccess, Action<Exception> onError) => single.Subscribe(new SingleObserver<T>(onSuccess, onError));
+
+        private class SingleObserver<T> : ISingleObserver<T>
+        {
+            private readonly Action<T> _onSuccess;
+            private readonly Action<Exception> _onError;
+
+            public SingleObserver(Action<T> onSuccess, Action<Exception> onError) { _onSuccess = onSuccess; _onError = onError; }
+
+            public void OnSuccess(T value) => _onSuccess(value);
+            public void OnError(Exception error)
+            {
+                if (_onError == null)
+                    throw error;
+                _onError(error);
+            }
+        }
+    }
+}

--- a/src/Daml.Ledger.Api.Data/util/Some.cs
+++ b/src/Daml.Ledger.Api.Data/util/Some.cs
@@ -1,0 +1,74 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+
+namespace Daml.Ledger.Api.Data.Util
+{
+    /// <summary>
+    /// An Optional wrapper for an actual value, as opposed to no value, or None
+    /// see http://codinghelmet.com/articles/custom-implementation-of-the-option-maybe-type-in-cs
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class Some<T> : Optional<T>, IEquatable<Some<T>>
+    {
+        public T Content { get; }
+
+        public Some(T value) { Content = value; }
+
+        public static implicit operator T(Some<T> some) => some.Content;
+
+        public static implicit operator Some<T>(T value) => new Some<T>(value);
+
+        // Return the value converted to the new type, which is then implicitly converted to an Optional of that type
+        public override Optional<TResult> Map<TResult>(Func<T, TResult> map) => map(Content); 
+
+        // Return an Optional of the new type - no conversion needed 
+        public override Optional<TResult> Map<TResult>(Func<T, Optional<TResult>> map) => map(Content);
+
+        public override TResult MapOrElse<TResult>(Func<T, TResult> map, Func<TResult> whenNone) => map(Content);
+        
+        // Return the existing Optional if the predicate returns true, otherwise None
+        public override Optional<T> Filter(Func<T, bool> predicate)
+        {
+            if (predicate(Content))
+                return this;
+            return None.Value;
+        }
+
+        public override T Reduce(T whenNone) => Content;
+
+        // No need to call the whenNone function as there is a value
+        public override T Reduce(Func<T> whenNone) => Content;
+
+        public bool Equals(Some<T> other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return EqualityComparer<T>.Default.Equals(Content, other.Content);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is Some<T> && Equals((Some<T>)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T>.Default.GetHashCode(Content);
+        }
+
+        public override string ToString() => $"Some({ContentToString})";
+
+        private string ContentToString => Content?.ToString() ?? "<null>";
+
+        public override bool IsPresent => true;
+
+        public override void IfPresent(Action<T> action) => action(Content);
+    }
+}

--- a/src/Daml.Ledger.Automation/StatefulBot.cs
+++ b/src/Daml.Ledger.Automation/StatefulBot.cs
@@ -31,9 +31,9 @@ namespace Daml.Ledger.Automation
             _handler = handler;
         }
 
-        public async Task Run(TransactionFilter transactionFilter, LedgerOffset beginOffset, LedgerOffset endOffset, bool verbose, TraceContext traceContext = null)
+        public async Task Run(TransactionFilter transactionFilter, LedgerOffset beginOffset, LedgerOffset endOffset, bool verbose, string accessToken = null, TraceContext traceContext = null)
         {
-            using (var stream = _transactionsClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, traceContext))
+            using (var stream = _transactionsClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, accessToken, traceContext))
             {
                 while (stream.MoveNext().Result)
                 {

--- a/src/Daml.Ledger.Automation/StatelessBot.cs
+++ b/src/Daml.Ledger.Automation/StatelessBot.cs
@@ -16,10 +16,10 @@ namespace DigitalAsset.Ledger.Automation
         private readonly ICommandClient _commandClient;
         private readonly Func<Transaction, Commands> _handler;
 
-        public StatelessBot(string ledgerId, Channel channel, Func<Transaction, Commands> handler)
+        public StatelessBot(string ledgerId, Channel channel, string accessToken, Func<Transaction, Commands> handler)
         {
-            _transactionClient = new TransactionsClient(ledgerId, channel);
-            _commandClient = new CommandClient(ledgerId, channel);
+            _transactionClient = new TransactionsClient(ledgerId, channel, accessToken);
+            _commandClient = new CommandClient(ledgerId, channel, accessToken);
             _handler = handler;
         }
 
@@ -28,9 +28,10 @@ namespace DigitalAsset.Ledger.Automation
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
-            using (var stream = _transactionClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, traceContext))
+            using (var stream = _transactionClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, accessToken, traceContext))
             {
                 while (stream.MoveNext().Result)
                 {

--- a/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
@@ -7,7 +7,8 @@ namespace Daml.Ledger.Client.Reactive
     using System.Reactive.Concurrency;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Reactive.Util;
-
+    using Daml.Ledger.Api.Data.Util;
+ 
     public class ActiveContractsClient
     {
         private readonly IActiveContractsClient _activeContractsClient;
@@ -19,9 +20,9 @@ namespace Daml.Ledger.Client.Reactive
             _scheduler = scheduler;
         }
 
-        public IObservable<GetActiveContractsResponse> GetActiveContracts(TransactionFilter transactionFilter, bool verbose = true, TraceContext traceContext = null)
+        public IObservable<GetActiveContractsResponse> GetActiveContracts(TransactionFilter transactionFilter, bool verbose = true, Optional<string> accessToken = null, TraceContext traceContext = null)
         {
-            return _activeContractsClient.GetActiveContracts(transactionFilter, verbose, traceContext).CreateAsyncObservable(_scheduler);
+            return _activeContractsClient.GetActiveContracts(transactionFilter, verbose, accessToken?.Reduce((string) null), traceContext).CreateAsyncObservable(_scheduler);
         }
     }
 }

--- a/src/Daml.Ledger.Client.Reactive/CommandClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandClient.cs
@@ -4,7 +4,9 @@
 namespace Daml.Ledger.Client.Reactive
 {
     using System;
-    using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Api.Data.Util;
+
+    using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;
 
     public class CommandClient
     {
@@ -15,9 +17,9 @@ namespace Daml.Ledger.Client.Reactive
             _commandClient = commandClient;
         }
 
-        public IDisposable Submit(IObservable<Commands> commands)
+        public IDisposable Submit(IObservable<Commands> commands, Optional<string> accessToken = null)
         {
-            return commands.Subscribe(_commandClient.SubmitAndWait);
+            return commands.Subscribe(c => _commandClient.SubmitAndWait(c , accessToken?.Reduce((string) null)));
         }
     }
 }

--- a/src/Daml.Ledger.Client.Reactive/CommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandCompletionClient.cs
@@ -6,8 +6,12 @@ namespace Daml.Ledger.Client.Reactive
     using System;
     using System.Reactive.Concurrency;
     using System.Collections.Generic;
-    using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Reactive.Util;
+    using Daml.Ledger.Api.Data.Util;
+
+    using CompletionStreamResponse = Com.DigitalAsset.Ledger.Api.V1.CompletionStreamResponse;
+    using LedgerOffset = Com.DigitalAsset.Ledger.Api.V1.LedgerOffset;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
 
     public class CommandCompletionClient
     {
@@ -19,15 +23,15 @@ namespace Daml.Ledger.Client.Reactive
             _commandCompletionClient = commandCompletionClient;
             _scheduler = scheduler;
         }
-
-        public IObservable<CompletionStreamResponse> GetLedgerConfiguration(string applicationId, LedgerOffset offset, IEnumerable<string> parties)
+        
+        public IObservable<CompletionStreamResponse> CompletionStream(string applicationId, Optional<LedgerOffset> offset, IEnumerable<string> parties, Optional<string> accessToken = null)
         {
-            return _commandCompletionClient.CompletionStream(applicationId, offset, parties).CreateAsyncObservable(_scheduler);
+            return _commandCompletionClient.CompletionStream(applicationId, offset.Reduce((LedgerOffset) null), parties, accessToken?.Reduce((string) null)).CreateAsyncObservable(_scheduler);
         }
         
-        public LedgerOffset CompletionEnd(TraceContext traceContext = null)
+        public LedgerOffset CompletionEnd(Optional<string> accessToken = null, TraceContext traceContext = null)
         {
-            return _commandCompletionClient.CompletionEnd(traceContext);
+            return _commandCompletionClient.CompletionEnd(accessToken?.Reduce((string) null), traceContext);
         } 
     }
 }

--- a/src/Daml.Ledger.Client.Reactive/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandSubmissionClient.cs
@@ -4,7 +4,9 @@
 namespace Daml.Ledger.Client.Reactive
 {
     using System;
-    using Com.DigitalAsset.Ledger.Api.V1;
+    using Daml.Ledger.Api.Data.Util;
+
+    using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;
 
     public class CommandSubmissionClient
     {
@@ -15,9 +17,9 @@ namespace Daml.Ledger.Client.Reactive
             _commandSubmissionClient = commandSubmissionClient;
         }
 
-        public IDisposable Submit(IObservable<Commands> commands)
+        public IDisposable Submit(IObservable<Commands> commands, Optional<string> accessToken = null)
         {
-            return commands.Subscribe(_commandSubmissionClient.Submit);
+            return commands.Subscribe(c => _commandSubmissionClient.Submit(c, accessToken?.Reduce((string) null)));
         }
     }
 }

--- a/src/Daml.Ledger.Client.Reactive/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/LedgerConfigurationClient.cs
@@ -5,23 +5,26 @@ namespace Daml.Ledger.Client.Reactive
 {
     using System;
     using System.Reactive.Concurrency;
-    using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Reactive.Util;
+    using Daml.Ledger.Api.Data.Util;
+
+    using GetLedgerConfigurationResponse = Com.DigitalAsset.Ledger.Api.V1.GetLedgerConfigurationResponse;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
 
     public class LedgerConfigurationClient
     {
         private readonly ILedgerConfigurationClient _ledgerConfigurationClient;
         private readonly IScheduler _scheduler;
 
-        public LedgerConfigurationClient(ILedgerConfigurationClient ledgerConfigurationClient, IScheduler scheduler)
+        public LedgerConfigurationClient(ILedgerConfigurationClient ledgerConfigurationClient, IScheduler scheduler = null)
         {
             _ledgerConfigurationClient = ledgerConfigurationClient;
             _scheduler = scheduler;
         }
 
-        public IObservable<GetLedgerConfigurationResponse> GetLedgerConfiguration(TraceContext traceContext = null)
+        public IObservable<GetLedgerConfigurationResponse> GetLedgerConfiguration(Optional<string> accessToken = null, TraceContext traceContext = null)
         {
-            return _ledgerConfigurationClient.GetLedgerConfiguration(traceContext).CreateAsyncObservable(_scheduler);
+            return _ledgerConfigurationClient.GetLedgerConfiguration(accessToken?.Reduce((string) null), traceContext).CreateAsyncObservable(_scheduler);
         }
     }
 }

--- a/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
@@ -5,16 +5,22 @@ namespace Daml.Ledger.Client.Reactive
 {
     using System;
     using System.Reactive.Concurrency;
-    using Com.DigitalAsset.Ledger.Api.V1;
     using Client;
     using Daml.Ledger.Client.Reactive.Util;
+    using Daml.Ledger.Api.Data.Util;
+    
+    using GetTransactionsResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionsResponse;
+    using GetTransactionTreesResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionTreesResponse;
+    using TransactionFilter = Com.DigitalAsset.Ledger.Api.V1.TransactionFilter;
+    using LedgerOffset = Com.DigitalAsset.Ledger.Api.V1.LedgerOffset;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
 
     public class TransactionsClient
     {
         private readonly ITransactionsClient _transactionsClient;
         private readonly IScheduler _scheduler;
 
-        public TransactionsClient(ITransactionsClient transactionsClient, IScheduler scheduler)
+        public TransactionsClient(ITransactionsClient transactionsClient, IScheduler scheduler = null)
         {
             _transactionsClient = transactionsClient;
             _scheduler = scheduler;
@@ -25,9 +31,10 @@ namespace Daml.Ledger.Client.Reactive
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            Optional<string> accessToken = null, 
             TraceContext traceContext = null)
         {
-            return _transactionsClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, traceContext).CreateAsyncObservable(_scheduler);
+            return _transactionsClient.GetTransactions(transactionFilter, beginOffset, endOffset, verbose, accessToken?.Reduce((string) null), traceContext).CreateAsyncObservable(_scheduler);
         }
 
         public IObservable<GetTransactionTreesResponse> GetTransactionTrees(
@@ -35,9 +42,10 @@ namespace Daml.Ledger.Client.Reactive
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            Optional<string> accessToken = null, 
             TraceContext traceContext = null)
         {
-            return _transactionsClient.GetTransactionTrees(transactionFilter, beginOffset, endOffset, verbose, traceContext).CreateAsyncObservable(_scheduler);
+            return _transactionsClient.GetTransactionTrees(transactionFilter, beginOffset, endOffset, verbose, accessToken?.Reduce((string) null), traceContext).CreateAsyncObservable(_scheduler);
         }
     }
 }

--- a/src/Daml.Ledger.Client/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/ActiveContractsClient.cs
@@ -13,28 +13,31 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<ActiveContractsService.ActiveContractsServiceClient> _activeContractsClient;
 
-        public ActiveContractsClient(string ledgerId, Channel channel)
+        public ActiveContractsClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _activeContractsClient = new ClientStub<ActiveContractsService.ActiveContractsServiceClient>(new ActiveContractsService.ActiveContractsServiceClient(channel));
+            _activeContractsClient = new ClientStub<ActiveContractsService.ActiveContractsServiceClient>(new ActiveContractsService.ActiveContractsServiceClient(channel), accessToken);
         }
 
         public IAsyncEnumerator<GetActiveContractsResponse> GetActiveContracts(
             TransactionFilter transactionFilter,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
             var request = new GetActiveContractsRequest { LedgerId = _ledgerId, Filter = transactionFilter, Verbose = verbose, TraceContext = traceContext };
-            var response = _activeContractsClient.Dispatch(request, (c, r, co) => c.GetActiveContracts(r, co));
+            var response = _activeContractsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetActiveContracts(r, co));
+
             return response.ResponseStream;
         }
 
         public IEnumerable<GetActiveContractsResponse> GetActiveContractsSync(
             TransactionFilter transactionFilter,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
-            using (var stream = GetActiveContracts(transactionFilter, verbose, traceContext))
+            using (var stream = GetActiveContracts(transactionFilter, verbose, accessToken, traceContext))
             {
                 while (stream.MoveNext().Result)
                 {

--- a/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
@@ -14,35 +14,33 @@ namespace Daml.Ledger.Client.Admin
     {
         private readonly ClientStub<ConfigManagementService.ConfigManagementServiceClient> _configManagementClient;
 
-        public ConfigManagementClient(Channel channel)
+        public ConfigManagementClient(Channel channel, string accessToken)
         {
-            _configManagementClient = new ClientStub<ConfigManagementService.ConfigManagementServiceClient>(new Com.DigitalAsset.Ledger.Api.V1.Admin.ConfigManagementService.ConfigManagementServiceClient(channel));
+            _configManagementClient = new ClientStub<ConfigManagementService.ConfigManagementServiceClient>(new Com.DigitalAsset.Ledger.Api.V1.Admin.ConfigManagementService.ConfigManagementServiceClient(channel), accessToken);
         }
 
-        public (TimeModel, long) GetTimeModel()
+        public (TimeModel, long) GetTimeModel(string accessToken = null)
         {
-            var response = _configManagementClient.Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModel(r, co));
+            var response = _configManagementClient.WithAccess(accessToken).Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModel(r, co));
             return (response.TimeModel, response.ConfigurationGeneration);
         }
 
-        public async Task<(TimeModel, long)> GetTimeModelAsync()
+        public async Task<(TimeModel, long)> GetTimeModelAsync(string accessToken = null)
         {
-            var response = await _configManagementClient.Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModelAsync(r, co));
+            var response = await _configManagementClient.WithAccess(accessToken).Dispatch(new GetTimeModelRequest(), (c, r, co) => c.GetTimeModelAsync(r, co));
             return (response.TimeModel, response.ConfigurationGeneration);
         }
 
-        public long SetTimeModel(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel)
+        public long SetTimeModel(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel, string accessToken = null)
         {
             var request = new SetTimeModelRequest { SubmissionId = submissionId, ConfigurationGeneration = configurationGeneration, MaximumRecordTime = Timestamp.FromDateTime(maximumRecordTime), NewTimeModel = newTimeModel };
-
-            return _configManagementClient.Dispatch(request, (c, r, co) => c.SetTimeModel(r, co).ConfigurationGeneration);
+            return _configManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SetTimeModel(r, co)).ConfigurationGeneration;
         }
 
-        public async Task<long> SetTimeModelAsync(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel)
+        public async Task<long> SetTimeModelAsync(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel, string accessToken = null)
         {
             var request = new SetTimeModelRequest { SubmissionId = submissionId, ConfigurationGeneration = configurationGeneration, MaximumRecordTime = Timestamp.FromDateTime(maximumRecordTime), NewTimeModel = newTimeModel };
-
-            var response = await _configManagementClient.Dispatch(request, (c, r, co) => c.SetTimeModelAsync(r, co));
+            var response = await _configManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SetTimeModelAsync(r, co));
                 
             return response.ConfigurationGeneration;
         }

--- a/src/Daml.Ledger.Client/Admin/IConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IConfigManagementClient.cs
@@ -9,12 +9,12 @@ namespace Daml.Ledger.Client.Admin
 
     public interface IConfigManagementClient
     {
-        (TimeModel, long) GetTimeModel();
+        (TimeModel, long) GetTimeModel(string accessToken = null);
 
-        Task<(TimeModel, long)> GetTimeModelAsync();
+        Task<(TimeModel, long)> GetTimeModelAsync(string accessToken = null);
 
-        long SetTimeModel(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel);
+        long SetTimeModel(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel, string accessToken = null);
 
-        Task<long> SetTimeModelAsync(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel);
+        Task<long> SetTimeModelAsync(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel, string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/Admin/IPackageManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IPackageManagementClient.cs
@@ -10,12 +10,12 @@ namespace Daml.Ledger.Client.Admin
 
     public interface IPackageManagementClient
     {
-        IEnumerable<PackageDetails> ListKnownPackages();
+        IEnumerable<PackageDetails> ListKnownPackages(string accessToken = null);
 
-        Task<IEnumerable<PackageDetails>> ListKnownPackagesAsync();
+        Task<IEnumerable<PackageDetails>> ListKnownPackagesAsync(string accessToken = null);
 
-        void UploadDarFile(Stream stream, string submissionId = null);
+        void UploadDarFile(Stream stream, string submissionId = null, string accessToken = null);
 
-        Task UploadDarFileAsync(Stream stream, string submissionId = null);
+        Task UploadDarFileAsync(Stream stream, string submissionId = null, string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/Admin/IPartyManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IPartyManagementClient.cs
@@ -9,16 +9,16 @@ namespace Daml.Ledger.Client.Admin
 
     public interface IPartyManagementClient
     {
-        PartyDetails AllocateParty(string displayName, string partyIdHint);
+        PartyDetails AllocateParty(string displayName, string partyIdHint, string accessToken = null);
 
-        Task<PartyDetails> AllocatePartyAsync(string displayName, string partyIdHint);
+        Task<PartyDetails> AllocatePartyAsync(string displayName, string partyIdHint, string accessToken = null);
 
-        string GetParticipantId();
+        string GetParticipantId(string accessToken = null);
 
-        Task<string> GetParticipantIdAsync();
+        Task<string> GetParticipantIdAsync(string accessToken = null);
 
-        IEnumerable<PartyDetails> ListKnownParties();
+        IEnumerable<PartyDetails> ListKnownParties(string accessToken = null);
 
-        Task<IEnumerable<PartyDetails>> ListKnownPartiesAsync();
+        Task<IEnumerable<PartyDetails>> ListKnownPartiesAsync(string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
@@ -15,40 +15,41 @@ namespace Daml.Ledger.Client.Admin
     {
         private readonly ClientStub<PackageManagementService.PackageManagementServiceClient> _packageManagementClient;
 
-        public PackageManagementClient(Channel channel)
+        public PackageManagementClient(Channel channel, string accessToken)
         {
-            _packageManagementClient = new ClientStub<PackageManagementService.PackageManagementServiceClient>(new PackageManagementService.PackageManagementServiceClient(channel));
+            _packageManagementClient = new ClientStub<PackageManagementService.PackageManagementServiceClient>(new PackageManagementService.PackageManagementServiceClient(channel), accessToken);
         }
 
-        public IEnumerable<PackageDetails> ListKnownPackages()
+        public IEnumerable<PackageDetails> ListKnownPackages(string accessToken = null)
         {
-            var response = _packageManagementClient.Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackages(r, co));
+            var response = _packageManagementClient.WithAccess(accessToken).Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackages(r, co));
             return response.PackageDetails;
         }
 
-        public async Task<IEnumerable<PackageDetails>> ListKnownPackagesAsync()
+        public async Task<IEnumerable<PackageDetails>> ListKnownPackagesAsync(string accessToken = null)
         {
-            var response = await _packageManagementClient.Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackagesAsync(r, co));
+            var response = await _packageManagementClient.WithAccess(accessToken).Dispatch(new ListKnownPackagesRequest(), (c, r, co) => c.ListKnownPackagesAsync(r, co));
+
             return response.PackageDetails;
         }
 
-        public void UploadDarFile(Stream stream, string submissionId = null)
+        public void UploadDarFile(Stream stream, string submissionId = null, string accessToken = null)
         {
             var request = new UploadDarFileRequest { DarFile = ByteString.FromStream(stream) };
             if (!string.IsNullOrEmpty(submissionId))
                 request.SubmissionId = submissionId;
             
-            _packageManagementClient.Dispatch(request, (c, r, co) => c.UploadDarFile(r, co));
+            _packageManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.UploadDarFile(r, co));
         }
 
-        public async Task UploadDarFileAsync(Stream stream, string submissionId = null)
+        public async Task UploadDarFileAsync(Stream stream, string submissionId = null, string accessToken = null)
         {
             var byteString = await ByteString.FromStreamAsync(stream);
             var request = new UploadDarFileRequest { DarFile = byteString };
             if (!string.IsNullOrEmpty(submissionId))
                 request.SubmissionId = submissionId;
-                
-            await _packageManagementClient.Dispatch(request, (c, r, co) => c.UploadDarFileAsync(r, co));
+
+            await _packageManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.UploadDarFileAsync(r, co));
         }
     }
 }

--- a/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
@@ -13,46 +13,46 @@ namespace Daml.Ledger.Client.Admin
     {
         private readonly ClientStub<PartyManagementService.PartyManagementServiceClient> _partyManagementClient;
 
-        public PartyManagementClient(Channel channel)
+        public PartyManagementClient(Channel channel, string accessToken)
         {
-            _partyManagementClient = new ClientStub<PartyManagementService.PartyManagementServiceClient>(new PartyManagementService.PartyManagementServiceClient(channel));
+            _partyManagementClient = new ClientStub<PartyManagementService.PartyManagementServiceClient>(new PartyManagementService.PartyManagementServiceClient(channel), accessToken);
         }
 
-        public PartyDetails AllocateParty(string displayName, string partyIdHint)
+        public PartyDetails AllocateParty(string displayName, string partyIdHint, string accessToken = null)
         {
             var request = new AllocatePartyRequest { DisplayName = displayName, PartyIdHint = partyIdHint };
-            var response = _partyManagementClient.Dispatch(request, (c, r, co) => c.AllocateParty(r, co));
+            var response = _partyManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.AllocateParty(r, co));
             return response.PartyDetails;
         }
 
-        public async Task<PartyDetails> AllocatePartyAsync(string displayName, string partyIdHint)
+        public async Task<PartyDetails> AllocatePartyAsync(string displayName, string partyIdHint, string accessToken = null)
         {
             var request = new AllocatePartyRequest { DisplayName = displayName, PartyIdHint = partyIdHint };
-            var response = await _partyManagementClient.Dispatch(request, (c, r, co) => c.AllocatePartyAsync(r, co));
+            var response = await _partyManagementClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.AllocatePartyAsync(r, co));
             return response.PartyDetails;
         }
 
-        public string GetParticipantId()
+        public string GetParticipantId(string accessToken = null)
         {
-            var response = _partyManagementClient.Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantId(r, co));
+            var response = _partyManagementClient.WithAccess(accessToken).Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantId(r, co));
             return response.ParticipantId;
         }
 
-        public async Task<string> GetParticipantIdAsync()
+        public async Task<string> GetParticipantIdAsync(string accessToken = null)
         {
-            var response = await _partyManagementClient.Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantIdAsync(r, co));
+            var response = await _partyManagementClient.WithAccess(accessToken).Dispatch(new GetParticipantIdRequest(), (c, r, co) => c.GetParticipantIdAsync(r, co));
             return response.ParticipantId;
         }
 
-        public IEnumerable<PartyDetails> ListKnownParties()
+        public IEnumerable<PartyDetails> ListKnownParties(string accessToken = null)
         {
-            var response = _partyManagementClient.Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownParties(r, co));
+            var response = _partyManagementClient.WithAccess(accessToken).Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownParties(r, co));
             return response.PartyDetails;
         }
 
-        public async Task<IEnumerable<PartyDetails>> ListKnownPartiesAsync()
+        public async Task<IEnumerable<PartyDetails>> ListKnownPartiesAsync(string accessToken = null)
         {
-            var response = await _partyManagementClient.Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownPartiesAsync(r, co));
+            var response = await _partyManagementClient.WithAccess(accessToken).Dispatch(new ListKnownPartiesRequest(), (c, r, co) => c.ListKnownPartiesAsync(r, co));
             return response.PartyDetails;
         }
     }

--- a/src/Daml.Ledger.Client/CommandClient.cs
+++ b/src/Daml.Ledger.Client/CommandClient.cs
@@ -16,10 +16,10 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<CommandService.CommandServiceClient> _commandClient;
 
-        public CommandClient(string ledgerId, Channel channel)
+        public CommandClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _commandClient = new ClientStub<CommandService.CommandServiceClient>(new CommandService.CommandServiceClient(channel));
+            _commandClient = new ClientStub<CommandService.CommandServiceClient>(new CommandService.CommandServiceClient(channel), accessToken);
         }
 
         public void SubmitAndWait(
@@ -29,9 +29,10 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
-            SubmitAndWait(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands));
+            SubmitAndWait(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands), accessToken);
         }
 
         public async Task SubmitAndWaitAsync(
@@ -41,19 +42,20 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
-            await SubmitAndWaitAsync(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands));
+            await SubmitAndWaitAsync(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands), accessToken);
         }
 
-        public void SubmitAndWait(Commands commands)
+        public void SubmitAndWait(Commands commands, string accessToken = null)
         {
-            _commandClient.Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWait(r, co));
+            _commandClient.WithAccess(accessToken).Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWait(r, co));
         }
 
-        public async Task SubmitAndWaitAsync(Commands commands)
+        public async Task SubmitAndWaitAsync(Commands commands, string accessToken = null)
         {
-            await _commandClient.Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWaitAsync(r, co));
+            await _commandClient.WithAccess(accessToken).Dispatch(new SubmitAndWaitRequest { Commands = commands }, (c, r, co) => c.SubmitAndWaitAsync(r, co));
         }
 
         public Transaction SubmitAndWaitForTransaction(
@@ -63,10 +65,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands, 
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransaction(r, co));
+            var response = _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransaction(r, co));
             return response.Transaction;
         }
 
@@ -77,10 +80,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands, 
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionId(r, co));
+            var response = _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionId(r, co));
             return response.TransactionId;
         }
 
@@ -91,10 +95,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTree(r, co));
+            var response = _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTree(r, co));
             return response.Transaction;
         }
 
@@ -105,10 +110,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionAsync(r, co));
+            var response = await _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionAsync(r, co));
             return response.Transaction;
         }
 
@@ -119,10 +125,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionIdAsync(r, co));
+            var response = await _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionIdAsync(r, co));
             return response.TransactionId;
         }
 
@@ -133,10 +140,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
             var request = new SubmitAndWaitRequest { Commands = BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands) };
-            var response = await _commandClient.Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTreeAsync(r, co));
+            var response = await _commandClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SubmitAndWaitForTransactionTreeAsync(r, co));
             return response.Transaction;
         }
 

--- a/src/Daml.Ledger.Client/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/CommandSubmissionClient.cs
@@ -16,10 +16,10 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<CommandSubmissionService.CommandSubmissionServiceClient> _commandSubmissionClient;
 
-        public CommandSubmissionClient(string ledgerId, Channel channel)
+        public CommandSubmissionClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _commandSubmissionClient = new ClientStub<CommandSubmissionService.CommandSubmissionServiceClient>(new CommandSubmissionService.CommandSubmissionServiceClient(channel));
+            _commandSubmissionClient = new ClientStub<CommandSubmissionService.CommandSubmissionServiceClient>(new CommandSubmissionService.CommandSubmissionServiceClient(channel), accessToken);
         }
 
         public void Submit(
@@ -29,9 +29,10 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
-            Submit(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands));
+            Submit(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands), accessToken);
         }
 
         public async Task SubmitAsync(
@@ -41,19 +42,20 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands)
+            IEnumerable<Command> commands,
+            string accessToken = null)
         {
-            await SubmitAsync(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands));
+            await SubmitAsync(BuildCommands(applicationId, workflowId, commandId, party, ledgerEffectiveTime, maximumRecordTime, commands), accessToken);
         }
 
-        public void Submit(Commands commands)
+        public void Submit(Commands commands, string accessToken = null)
         {
-            _commandSubmissionClient.Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.Submit(r, co));
+            _commandSubmissionClient.WithAccess(accessToken).Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.Submit(r, co));
         }
 
-        public async Task SubmitAsync(Commands commands)
+        public async Task SubmitAsync(Commands commands, string accessToken = null)
         {
-            await _commandSubmissionClient.Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.SubmitAsync(r, co));
+            await _commandSubmissionClient.WithAccess(accessToken).Dispatch(new SubmitRequest { Commands = commands }, (c, r, co) => c.SubmitAsync(r, co));
         }
 
         private Commands BuildCommands(

--- a/src/Daml.Ledger.Client/IActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/IActiveContractsClient.cs
@@ -11,11 +11,13 @@ namespace Daml.Ledger.Client
         IAsyncEnumerator<GetActiveContractsResponse> GetActiveContracts(
             TransactionFilter transactionFilter,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null);
 
         IEnumerable<GetActiveContractsResponse> GetActiveContractsSync(
                 TransactionFilter transactionFilter,
                 bool verbose = true,
+                string accessToken = null,
                 TraceContext traceContext = null);
     }
 }

--- a/src/Daml.Ledger.Client/ICommandClient.cs
+++ b/src/Daml.Ledger.Client/ICommandClient.cs
@@ -17,7 +17,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         Task SubmitAndWaitAsync(
             string applicationId,
@@ -26,11 +27,12 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
-        void SubmitAndWait(Commands commands);
+        void SubmitAndWait(Commands commands, string accessToken = null);
 
-        Task SubmitAndWaitAsync(Commands commands);
+        Task SubmitAndWaitAsync(Commands commands, string accessToken = null);
 
         Transaction SubmitAndWaitForTransaction(
             string applicationId,
@@ -39,7 +41,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         string SubmitAndWaitForTransactionId(
             string applicationId,
@@ -48,7 +51,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         TransactionTree SubmitAndWaitForTransactionTree(
             string applicationId,
@@ -57,7 +61,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         Task<Transaction> SubmitAndWaitForTransactionAsync(
             string applicationId,
@@ -66,7 +71,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         Task<string> SubmitAndWaitForTransactionIdAsync(
             string applicationId,
@@ -75,7 +81,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         Task<TransactionTree> SubmitAndWaitForTransactionTreeAsync(
             string applicationId,
@@ -84,6 +91,7 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/ICommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandCompletionClient.cs
@@ -9,12 +9,12 @@ namespace Daml.Ledger.Client
 
     public interface ICommandCompletionClient
     {
-        IAsyncEnumerator<CompletionStreamResponse> CompletionStream(string applicationId, LedgerOffset offset, IEnumerable<string> parties);
+        IAsyncEnumerator<CompletionStreamResponse> CompletionStream(string applicationId, LedgerOffset offset, IEnumerable<string> parties, string accessToken = null);
 
-        IEnumerable<CompletionStreamResponse> CompletionStreamSync(string applicationId, LedgerOffset offset, IEnumerable<string> parties);
+        IEnumerable<CompletionStreamResponse> CompletionStreamSync(string applicationId, LedgerOffset offset, IEnumerable<string> parties, string accessToken = null);
 
-        LedgerOffset CompletionEnd(TraceContext traceContext = null);
+        LedgerOffset CompletionEnd(string accessToken = null, TraceContext traceContext = null);
 
-        Task<LedgerOffset> CompletionEndAsync(TraceContext traceContext = null);
+        Task<LedgerOffset> CompletionEndAsync(string accessToken = null, TraceContext traceContext = null);
     }
 }

--- a/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
@@ -17,7 +17,8 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
         Task SubmitAsync(
             string applicationId,
@@ -26,10 +27,11 @@ namespace Daml.Ledger.Client
             string party,
             DateTime ledgerEffectiveTime,
             DateTime maximumRecordTime,
-            IEnumerable<Command> commands);
+            IEnumerable<Command> commands,
+            string accessToken = null);
 
-        void Submit(Commands commands);
+        void Submit(Commands commands, string accessToken = null);
 
-        Task SubmitAsync(Commands commands);
+        Task SubmitAsync(Commands commands, string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
@@ -8,8 +8,8 @@ namespace Daml.Ledger.Client
 
     public interface ILedgerConfigurationClient
     {
-        IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(TraceContext traceContext = null);
+        IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(string accessToken = null, TraceContext traceContext = null);
 
-        IEnumerable<GetLedgerConfigurationResponse> GetLedgerConfigurationSync(TraceContext traceContext = null);
+        IEnumerable<GetLedgerConfigurationResponse> GetLedgerConfigurationSync(string accessToken = null, TraceContext traceContext = null);
     }
 }

--- a/src/Daml.Ledger.Client/ILedgerIdentitiyClient.cs
+++ b/src/Daml.Ledger.Client/ILedgerIdentitiyClient.cs
@@ -7,8 +7,8 @@ namespace Daml.Ledger.Client
 
     public interface ILedgerIdentityClient
     {
-        string GetLedgerIdentity();
+        string GetLedgerIdentity(string accessToken = null);
 
-        Task<string> GetLedgerIdentityAsync();
+        Task<string> GetLedgerIdentityAsync(string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/IPackageClient.cs
+++ b/src/Daml.Ledger.Client/IPackageClient.cs
@@ -9,16 +9,16 @@ namespace Daml.Ledger.Client
 
     public interface IPackageClient
     {
-        GetPackageResponse GetPackage(string packageId, TraceContext traceContext = null);
+        GetPackageResponse GetPackage(string packageId, string accessToken = null, TraceContext traceContext = null);
 
-        Task<GetPackageResponse> GetPackageAsync(string packageId, TraceContext traceContext = null);
+        Task<GetPackageResponse> GetPackageAsync(string packageId, string accessToken = null, TraceContext traceContext = null);
 
-        PackageStatus GetPackageStatus(string packageId, TraceContext traceContext = null);
+        PackageStatus GetPackageStatus(string packageId, string accessToken = null, TraceContext traceContext = null);
 
-        Task<PackageStatus> GetPackageStatusAsync(string packageId, TraceContext traceContext = null);
+        Task<PackageStatus> GetPackageStatusAsync(string packageId, string accessToken = null, TraceContext traceContext = null);
 
-        IEnumerable<string> ListPackages(TraceContext traceContext = null);
+        IEnumerable<string> ListPackages(string accessToken = null, TraceContext traceContext = null);
 
-        Task<IEnumerable<string>> ListPackagesAsync(TraceContext traceContext = null);
+        Task<IEnumerable<string>> ListPackagesAsync(string accessToken = null, TraceContext traceContext = null);
     }
 }

--- a/src/Daml.Ledger.Client/ITransactionsClient.cs
+++ b/src/Daml.Ledger.Client/ITransactionsClient.cs
@@ -9,31 +9,32 @@ namespace Daml.Ledger.Client
 
     public interface ITransactionsClient
     {
-        GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        LedgerOffset GetLedgerEnd(TraceContext traceContext = null);
+        LedgerOffset GetLedgerEnd(string accessToken = null, TraceContext traceContext = null);
 
-        Task<LedgerOffset> GetLedgerEndAsync(TraceContext traceContext = null);
+        Task<LedgerOffset> GetLedgerEndAsync(string accessToken = null, TraceContext traceContext = null);
 
-        GetTransactionResponse GetTransactionByEventId(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        GetTransactionResponse GetTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
-        Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null);
+        Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
         IAsyncEnumerator<GetTransactionsResponse> GetTransactions(
             TransactionFilter transactionFilter,
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null);
 
         IEnumerable<GetTransactionsResponse> GetTransactionsSync(
@@ -41,6 +42,7 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null);
 
         IAsyncEnumerator<GetTransactionTreesResponse> GetTransactionTrees(
@@ -48,6 +50,7 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null);
 
         IEnumerable<GetTransactionTreesResponse> GetTransactionTreesSync(
@@ -55,6 +58,7 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null);
     }
 }

--- a/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
@@ -13,22 +13,22 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient> _ledgerConfigurationClient;
 
-        public LedgerConfigurationClient(string ledgerId, Channel channel)
+        public LedgerConfigurationClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _ledgerConfigurationClient = new ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient>(new LedgerConfigurationService.LedgerConfigurationServiceClient(channel));
+            _ledgerConfigurationClient = new ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient>(new LedgerConfigurationService.LedgerConfigurationServiceClient(channel), accessToken);
         }
 
-        public IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(TraceContext traceContext = null)
+        public IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetLedgerConfigurationRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _ledgerConfigurationClient.Dispatch(request, (c, r, co) => c.GetLedgerConfiguration(r, co));
+            var response = _ledgerConfigurationClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerConfiguration(r, co));
             return response.ResponseStream;
         }
 
-        public IEnumerable<GetLedgerConfigurationResponse> GetLedgerConfigurationSync(TraceContext traceContext = null)
+        public IEnumerable<GetLedgerConfigurationResponse> GetLedgerConfigurationSync(string accessToken = null, TraceContext traceContext = null)
         {
-            var r = GetLedgerConfiguration(traceContext);
+            var r = GetLedgerConfiguration(accessToken, traceContext);
             while (r.MoveNext().Result)
             {
                 yield return r.Current;

--- a/src/Daml.Ledger.Client/LedgerIdentityClient.cs
+++ b/src/Daml.Ledger.Client/LedgerIdentityClient.cs
@@ -12,20 +12,20 @@ namespace Daml.Ledger.Client
     {
         private readonly ClientStub<LedgerIdentityService.LedgerIdentityServiceClient> _ledgerIdentityClient;
 
-        public LedgerIdentityClient(Channel channel)
+        public LedgerIdentityClient(Channel channel, string accessToken)
         {
-            _ledgerIdentityClient = new ClientStub<LedgerIdentityService.LedgerIdentityServiceClient>(new LedgerIdentityService.LedgerIdentityServiceClient(channel));
+            _ledgerIdentityClient = new ClientStub<LedgerIdentityService.LedgerIdentityServiceClient>(new LedgerIdentityService.LedgerIdentityServiceClient(channel), accessToken);
         }
 
-        public string GetLedgerIdentity()
+        public string GetLedgerIdentity(string accessToken = null)
         {
-            var response = _ledgerIdentityClient.Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentity(r, co));
+            var response = _ledgerIdentityClient.WithAccess(accessToken).Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentity(r, co));
             return response.LedgerId;
         }
 
-        public async Task<string> GetLedgerIdentityAsync()
+        public async Task<string> GetLedgerIdentityAsync(string accessToken = null)
         {
-            var response = await _ledgerIdentityClient.Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentityAsync(r, co));
+            var response = await _ledgerIdentityClient.WithAccess(accessToken).Dispatch(new GetLedgerIdentityRequest(), (c, r, co) => c.GetLedgerIdentityAsync(r, co));
             return response.LedgerId;
         }
     }

--- a/src/Daml.Ledger.Client/PackageClient.cs
+++ b/src/Daml.Ledger.Client/PackageClient.cs
@@ -14,49 +14,50 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<PackageService.PackageServiceClient> _packageClient;
 
-        public PackageClient(string ledgerId, Channel channel)
+        public PackageClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _packageClient = new ClientStub<PackageService.PackageServiceClient>(new PackageService.PackageServiceClient(channel));
+            _packageClient = new ClientStub<PackageService.PackageServiceClient>(new PackageService.PackageServiceClient(channel), accessToken);
         }
 
-        public GetPackageResponse GetPackage(string packageId, TraceContext traceContext = null)
+        public GetPackageResponse GetPackage(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            return _packageClient.Dispatch(request, (c, r, co) => c.GetPackage(r, co));
+            return _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackage(r, co));
         }
 
-        public async Task<GetPackageResponse> GetPackageAsync(string packageId, TraceContext traceContext = null)
+        public async Task<GetPackageResponse> GetPackageAsync(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            return await _packageClient.Dispatch(request, (c, r, co) => c.GetPackageAsync(r, co));
+            return await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageAsync(r, co));
         }
 
-        public PackageStatus GetPackageStatus(string packageId, TraceContext traceContext = null)
+        public PackageStatus GetPackageStatus(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            var response = _packageClient.Dispatch(request, (c, r, co) => c.GetPackageStatus(r, co));
+            var response = _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageStatus(r, co));
+
             return response.PackageStatus;
         }
 
-        public async Task<PackageStatus> GetPackageStatusAsync(string packageId, TraceContext traceContext = null)
+        public async Task<PackageStatus> GetPackageStatusAsync(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
-            var response = await _packageClient.Dispatch(request, (c, r, co) => c.GetPackageStatusAsync(r, co));
+            var response = await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageStatusAsync(r, co));
             return response.PackageStatus;
         }
 
-        public IEnumerable<string> ListPackages(TraceContext traceContext = null)
+        public IEnumerable<string> ListPackages(string accessToken = null, TraceContext traceContext = null)
         {
             var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _packageClient.Dispatch(request, (c, r, co) => c.ListPackages(r, co));
+            var response = _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.ListPackages(r, co));
             return response.PackageIds;
         }
 
-        public async Task<IEnumerable<string>> ListPackagesAsync(TraceContext traceContext = null)
+        public async Task<IEnumerable<string>> ListPackagesAsync(string accessToken = null, TraceContext traceContext = null)
         {
             var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = await _packageClient.Dispatch(request, (c, r, co) => c.ListPackagesAsync(r, co));
+            var response = await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.ListPackagesAsync(r, co));
             return response.PackageIds;
         }
     }

--- a/src/Daml.Ledger.Client/Testing/IResetClient.cs
+++ b/src/Daml.Ledger.Client/Testing/IResetClient.cs
@@ -7,8 +7,8 @@ namespace Daml.Ledger.Client.Testing
 
     public interface IResetClient
     {
-        void Reset();
+        void Reset(string accessToken = null);
 
-        Task ResetAsync();
+        Task ResetAsync(string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/Testing/ITimeClient.cs
+++ b/src/Daml.Ledger.Client/Testing/ITimeClient.cs
@@ -10,12 +10,12 @@ namespace Daml.Ledger.Client.Testing
 
     public interface ITimeClient
     {
-        IAsyncEnumerator<GetTimeResponse> GetTime();
+        IAsyncEnumerator<GetTimeResponse> GetTime(string accessToken = null);
 
-        IEnumerable<GetTimeResponse> GetTimeSync();
+        IEnumerable<GetTimeResponse> GetTimeSync(string accessToken = null);
 
-        void SetTime(DateTime currentTime, DateTime newTime);
+        void SetTime(DateTime currentTime, DateTime newTime, string accessToken = null);
 
-        Task SetTimeAsync(DateTime currentTime, DateTime newTime);
+        Task SetTimeAsync(DateTime currentTime, DateTime newTime, string accessToken = null);
     }
 }

--- a/src/Daml.Ledger.Client/Testing/ResetClient.cs
+++ b/src/Daml.Ledger.Client/Testing/ResetClient.cs
@@ -13,20 +13,20 @@ namespace Daml.Ledger.Client.Testing
         private readonly string _ledgerId;
         private readonly ClientStub<ResetService.ResetServiceClient> _resetClient;
 
-        public ResetClient(string ledgerId, Channel channel)
+        public ResetClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _resetClient = new ClientStub<ResetService.ResetServiceClient>(new ResetService.ResetServiceClient(channel));
+            _resetClient = new ClientStub<ResetService.ResetServiceClient>(new ResetService.ResetServiceClient(channel), accessToken);
         }
 
-        public void Reset()
+        public void Reset(string accessToken = null)
         {
-            _resetClient.Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.Reset(r, co));
+            _resetClient.WithAccess(accessToken).Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.Reset(r, co));
         }
 
-        public async Task ResetAsync()
+        public async Task ResetAsync(string accessToken = null)
         {
-            await _resetClient.Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.ResetAsync(r, co));
+            await _resetClient.WithAccess(accessToken).Dispatch(new ResetRequest { LedgerId = _ledgerId }, (c, r, co) => c.ResetAsync(r, co));
         }
     }
 }

--- a/src/Daml.Ledger.Client/Testing/TimeClient.cs
+++ b/src/Daml.Ledger.Client/Testing/TimeClient.cs
@@ -16,21 +16,21 @@ namespace Daml.Ledger.Client.Testing
         private readonly string _ledgerId;
         private readonly ClientStub<TimeService.TimeServiceClient> _timeClient;
 
-        public TimeClient(string ledgerId, Channel channel)
+        public TimeClient(string ledgerId, Channel channel, string accessToken)
         {
-          _ledgerId = ledgerId;
-           _timeClient = new ClientStub<TimeService.TimeServiceClient>(new TimeService.TimeServiceClient(channel));
+            _ledgerId = ledgerId;
+            _timeClient = new ClientStub<TimeService.TimeServiceClient>(new TimeService.TimeServiceClient(channel), accessToken);
         }
 
-        public IAsyncEnumerator<GetTimeResponse> GetTime()
+        public IAsyncEnumerator<GetTimeResponse> GetTime(string accessToken = null)
         {
-            var response = _timeClient.Dispatch(new GetTimeRequest { LedgerId = _ledgerId }, (c, r, co) => c.GetTime(r, co));
+            var response = _timeClient.WithAccess(accessToken).Dispatch(new GetTimeRequest { LedgerId = _ledgerId }, (c, r, co) => c.GetTime(r, co));
             return response.ResponseStream;
         }
 
-        public IEnumerable<GetTimeResponse> GetTimeSync()
+        public IEnumerable<GetTimeResponse> GetTimeSync(string accessToken = null)
         {
-            using (var stream = GetTime())
+            using (var stream = GetTime(accessToken))
             {
                 while (stream.MoveNext().Result)
                 {
@@ -39,21 +39,21 @@ namespace Daml.Ledger.Client.Testing
             }
         }
 
-        public void SetTime(DateTime currentTime, DateTime newTime)
+        public void SetTime(DateTime currentTime, DateTime newTime, string accessToken = null)
         {
-              if (currentTime >= newTime)
+            if (currentTime >= newTime)
                 throw new SetTimeException(currentTime, newTime);
 
             var request = new SetTimeRequest { LedgerId = _ledgerId, CurrentTime = Timestamp.FromDateTime(currentTime), NewTime = Timestamp.FromDateTime(newTime) };
-             _timeClient.Dispatch(request, (c, r, co) => c.SetTime(r, co));
+            _timeClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SetTime(r, co));
         }
 
-        public async Task SetTimeAsync(DateTime currentTime, DateTime newTime)
+        public async Task SetTimeAsync(DateTime currentTime, DateTime newTime, string accessToken = null)
         {
             var request = new SetTimeRequest { LedgerId = _ledgerId, CurrentTime = Timestamp.FromDateTime(currentTime), NewTime = Timestamp.FromDateTime(newTime) };
-            await _timeClient.Dispatch(request, (c, r, co) => c.SetTimeAsync(r, co));
+            await _timeClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.SetTimeAsync(r, co));
         }
-        
+
         private class SetTimeException : Exception
         {
             public SetTimeException(DateTimeOffset currentTime, DateTimeOffset newTime)

--- a/src/Daml.Ledger.Client/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client/TransactionsClient.cs
@@ -14,80 +14,80 @@ namespace Daml.Ledger.Client
         private readonly string _ledgerId;
         private readonly ClientStub<TransactionService.TransactionServiceClient> _transactionsClient;
 
-        public TransactionsClient(string ledgerId, Channel channel)
+        public TransactionsClient(string ledgerId, Channel channel, string accessToken)
         {
             _ledgerId = ledgerId;
-            _transactionsClient = new ClientStub<TransactionService.TransactionServiceClient>(new TransactionService.TransactionServiceClient(channel));
+            _transactionsClient = new ClientStub<TransactionService.TransactionServiceClient>(new TransactionService.TransactionServiceClient(channel), accessToken);
         }
 
-        public GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventId(r, co));
+            return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventId(r, co));
         }
 
-        public async Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public async Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventIdAsync(r, co));
+            return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventIdAsync(r, co));
         }
 
-        public GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionById(r, co));
+            return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionById(r, co));
         }
 
-        public async Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public async Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetFlatTransactionByIdAsync(r, co));
+            return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByIdAsync(r, co));
         }
 
-        public LedgerOffset GetLedgerEnd(TraceContext traceContext = null)
+        public LedgerOffset GetLedgerEnd(string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetLedgerEnd(r, co));
+            var response = _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerEnd(r, co));
             return response.Offset;
         }
 
-        public async Task<LedgerOffset> GetLedgerEndAsync(TraceContext traceContext = null)
+        public async Task<LedgerOffset> GetLedgerEndAsync(string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
-            var response = await _transactionsClient.Dispatch(request, (c, r, co) => c.GetLedgerEndAsync(r, co));
+            var response = await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerEndAsync(r, co));
             return response.Offset;
         }
 
-        public GetTransactionResponse GetTransactionByEventId(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public GetTransactionResponse GetTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByEventId(r, co));
+            return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByEventId(r, co));
         }
 
-        public async Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public async Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByEventIdAsync(r, co));
+            return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByEventIdAsync(r, co));
         }
 
-        public GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionById(r, co));
+            return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionById(r, co));
         }
 
-        public async Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, TraceContext traceContext = null)
+        public async Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
             var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
-            return await _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionByIdAsync(r, co));
+            return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByIdAsync(r, co));
         }
 
         public IAsyncEnumerator<GetTransactionsResponse> GetTransactions(
@@ -95,6 +95,7 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
             var request = new GetTransactionsRequest
@@ -106,7 +107,7 @@ namespace Daml.Ledger.Client
                     Verbose = verbose,
                     TraceContext = traceContext
                 };
-            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactions(r, co));
+            var response = _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactions(r, co));
             return response.ResponseStream;
         }
 
@@ -115,9 +116,10 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
-            using (var stream = GetTransactions(transactionFilter, beginOffset, endOffset, verbose, traceContext))
+            using (var stream = GetTransactions(transactionFilter, beginOffset, endOffset, verbose, accessToken, traceContext))
             {
                 while (stream.MoveNext().Result)
                 {
@@ -131,6 +133,7 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
             var request = new GetTransactionsRequest
@@ -142,7 +145,7 @@ namespace Daml.Ledger.Client
                     Verbose = verbose,
                     TraceContext = traceContext
                 };
-            var response = _transactionsClient.Dispatch(request, (c, r, co) => c.GetTransactionTrees(r, co));
+            var response = _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionTrees(r, co));
             return response.ResponseStream;
         }
 
@@ -151,9 +154,10 @@ namespace Daml.Ledger.Client
             LedgerOffset beginOffset,
             LedgerOffset endOffset = null,
             bool verbose = true,
+            string accessToken = null,
             TraceContext traceContext = null)
         {
-            using (var stream = GetTransactionTrees(transactionFilter, beginOffset, endOffset, verbose, traceContext))
+            using (var stream = GetTransactionTrees(transactionFilter, beginOffset, endOffset, verbose, accessToken, traceContext))
             {
                 while (stream.MoveNext().Result)
                 {


### PR DESCRIPTION
Added access token argument to all service client methods. 
Added the start of the Api.Data project but with just versions of Optional and Single ready for use in the ReactiveClient later, but also to wrap the accesstokens in the reactive layer.
Note that accessTokens default to null in the method calls but I have left them as required when creating the service client objects.