### PR TITLE
Namespaces

### DIFF
--- a/src/Daml.Ledger.Api.Data.Test/Daml.Ledger.Api.Data.Test.csproj
+++ b/src/Daml.Ledger.Api.Data.Test/Daml.Ledger.Api.Data.Test.csproj
@@ -18,12 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Admin\" />
-    <Folder Include="Auth\" />
-    <Folder Include="Testing\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/src/Daml.Ledger.Api.Data.Test/util/OptionalExtensionsTest.cs
+++ b/src/Daml.Ledger.Api.Data.Test/util/OptionalExtensionsTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using Daml.Ledger.Api.Data.Util;
 using NUnit.Framework;
 
 namespace Daml.Ledger.Api.Data.Util.Test

--- a/src/Daml.Ledger.Api.Data/Daml.Ledger.Api.Data.csproj
+++ b/src/Daml.Ledger.Api.Data/Daml.Ledger.Api.Data.csproj
@@ -31,12 +31,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Admin\" />
-    <Folder Include="Auth\" />
-    <Folder Include="Testing\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.5" />
   </ItemGroup>
 

--- a/src/Daml.Ledger.Automation/StatefulBot.cs
+++ b/src/Daml.Ledger.Automation/StatefulBot.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Automation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client;
 

--- a/src/Daml.Ledger.Automation/StatelessBot.cs
+++ b/src/Daml.Ledger.Automation/StatelessBot.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace DigitalAsset.Ledger.Automation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client;
-    using Grpc.Core;
 
     public class StatelessBot
     {

--- a/src/Daml.Ledger.Client.Reactive.Test/util/ServerStreamHelperTest.cs
+++ b/src/Daml.Ledger.Client.Reactive.Test/util/ServerStreamHelperTest.cs
@@ -6,11 +6,12 @@ using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading;
-using Daml.Ledger.Client.Reactive.Util;
 using NUnit.Framework;
 
 namespace Daml.Ledger.Client.Reactive.Test.Util
 {
+    using Daml.Ledger.Client.Reactive.Util;
+
     [TestFixture, Explicit]  // Tests take 10 seconds or so each...
     public class ServerStreamHelperTest
     {

--- a/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Reactive.Concurrency;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
-    using System.Reactive.Concurrency;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;

--- a/src/Daml.Ledger.Client.Reactive/CommandClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandClient.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
     using Daml.Ledger.Api.Data.Util;
 
     using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;

--- a/src/Daml.Ledger.Client.Reactive/CommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandCompletionClient.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Reactive.Concurrency;
+using System.Collections.Generic;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
-    using System.Reactive.Concurrency;
-    using System.Collections.Generic;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;
 

--- a/src/Daml.Ledger.Client.Reactive/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/CommandSubmissionClient.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
     using Daml.Ledger.Api.Data.Util;
 
     using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;

--- a/src/Daml.Ledger.Client.Reactive/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/LedgerConfigurationClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Reactive.Concurrency;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
-    using System.Reactive.Concurrency;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;
 

--- a/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
@@ -1,19 +1,15 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Reactive.Concurrency;
+
 namespace Daml.Ledger.Client.Reactive
 {
-    using System;
-    using System.Reactive.Concurrency;
     using Client;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;
-    
-    using GetTransactionsResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionsResponse;
-    using GetTransactionTreesResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionTreesResponse;
-    using TransactionFilter = Com.DigitalAsset.Ledger.Api.V1.TransactionFilter;
-    using LedgerOffset = Com.DigitalAsset.Ledger.Api.V1.LedgerOffset;
-    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
+    using Com.DigitalAsset.Ledger.Api.V1;
 
     public class TransactionsClient
     {

--- a/src/Daml.Ledger.Client.Test/Auth/Client/ClientStubTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/ClientStubTest.cs
@@ -1,13 +1,13 @@
 // Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using Daml.Ledger.Client.Auth.Client;
-using Google.Api;
 using Grpc.Core;
 using NUnit.Framework;
 
 namespace Daml.Ledger.Client.Test.Auth.Client
 {
+    using Daml.Ledger.Client.Auth.Client;
+
     public class ServiceClient
     {
         public MeaningOfLifeResponse WhatIsTheMeaningOfLife(MeaningOfLifeRequest request, CallOptions callOptions) => new MeaningOfLifeResponse();

--- a/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallCredentialsTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallCredentialsTest.cs
@@ -1,15 +1,13 @@
 // Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Grpc.Core;
 using NUnit.Framework;
-using Daml.Ledger.Client.Auth.Client;
 
 namespace Daml.Ledger.Client.Test.Auth.Client
 {
+    using Daml.Ledger.Client.Auth.Client;
+
     [TestFixture]
     public class LedgerCallOptionsTest
     {

--- a/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallOptionsTest.cs
+++ b/src/Daml.Ledger.Client.Test/Auth/Client/LedgerCallOptionsTest.cs
@@ -6,10 +6,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using NUnit.Framework;
-using Daml.Ledger.Client.Auth.Client;
 
 namespace Daml.Ledger.Client.Test.Auth.Client
 {
+    using Daml.Ledger.Client.Auth.Client;
+
     [TestFixture]
     public class LedgerCallCredentialsTest
     {

--- a/src/Daml.Ledger.Client/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/ActiveContractsClient.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class ActiveContractsClient : IActiveContractsClient
     {

--- a/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/ConfigManagementClient.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Google.Protobuf.WellKnownTypes;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System;
-    using System.Threading.Tasks;
-    using Grpc.Core;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
     using Daml.Ledger.Client.Auth.Client;
-    using Google.Protobuf.WellKnownTypes;
 
     public class ConfigManagementClient : IConfigManagementClient
     {

--- a/src/Daml.Ledger.Client/Admin/IConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IConfigManagementClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
 
     public interface IConfigManagementClient

--- a/src/Daml.Ledger.Client/Admin/IPackageManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IPackageManagementClient.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
 
     public interface IPackageManagementClient

--- a/src/Daml.Ledger.Client/Admin/IPartyManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/IPartyManagementClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
 
     public interface IPartyManagementClient

--- a/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PackageManagementClient.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
     using Daml.Ledger.Client.Auth.Client;
-    using Google.Protobuf;
-    using Grpc.Core;
 
     public class PackageManagementClient : IPackageManagementClient
     {

--- a/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
+++ b/src/Daml.Ledger.Client/Admin/PartyManagementClient.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Admin
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Admin;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class PartyManagementClient : IPartyManagementClient
     {

--- a/src/Daml.Ledger.Client/Auth/Client/ClientStub.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/ClientStub.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Auth.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using Grpc.Core;
-
     /// <summary>
     /// A stub around a gRPC client class, to ease management of access tokens. So named to mimic the Java use case somewhat.
     /// </summary>

--- a/src/Daml.Ledger.Client/Auth/Client/LedgerCallCredentials.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/LedgerCallCredentials.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Linq;
+using Grpc.Core;
+using Grpc.Core.Utils;
+
 namespace Daml.Ledger.Client.Auth.Client
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Grpc.Core;
-    using Grpc.Core.Utils;
-
     /// <summary>
     ///  See https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs and https://docs.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz?view=aspnetcore-3.1 for guidance/inspiration
     /// </summary>

--- a/src/Daml.Ledger.Client/Auth/Client/LedgerCallOptions.cs
+++ b/src/Daml.Ledger.Client/Auth/Client/LedgerCallOptions.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Linq;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Auth.Client
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Grpc.Core;
-
     /// <summary>
     ///  See https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs and https://docs.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz?view=aspnetcore-3.1 for guidance/inspiration
     /// </summary>

--- a/src/Daml.Ledger.Client/Clients.cs
+++ b/src/Daml.Ledger.Client/Clients.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System;
     using Admin;
     using Testing;
-    using Grpc.Core;
 
     public class Clients
     {

--- a/src/Daml.Ledger.Client/CommandClient.cs
+++ b/src/Daml.Ledger.Client/CommandClient.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Google.Protobuf.WellKnownTypes;
-    using Grpc.Core;
 
     public class CommandClient : ICommandClient
     {

--- a/src/Daml.Ledger.Client/CommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client/CommandCompletionClient.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class CommandCompletionClient : ICommandCompletionClient
     {

--- a/src/Daml.Ledger.Client/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/CommandSubmissionClient.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Google.Protobuf.WellKnownTypes;
-    using Grpc.Core;
 
     public class CommandSubmissionClient : ICommandSubmissionClient
     {

--- a/src/Daml.Ledger.Client/IActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/IActiveContractsClient.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface IActiveContractsClient

--- a/src/Daml.Ledger.Client/ICommandClient.cs
+++ b/src/Daml.Ledger.Client/ICommandClient.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface ICommandClient

--- a/src/Daml.Ledger.Client/ICommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandCompletionClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface ICommandCompletionClient

--- a/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface ICommandSubmissionClient

--- a/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface ILedgerConfigurationClient

--- a/src/Daml.Ledger.Client/ILedgerIdentitiyClient.cs
+++ b/src/Daml.Ledger.Client/ILedgerIdentitiyClient.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System.Threading.Tasks;
-
     public interface ILedgerIdentityClient
     {
         string GetLedgerIdentity(string accessToken = null);

--- a/src/Daml.Ledger.Client/IPackageClient.cs
+++ b/src/Daml.Ledger.Client/IPackageClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface IPackageClient

--- a/src/Daml.Ledger.Client/ITransactionsClient.cs
+++ b/src/Daml.Ledger.Client/ITransactionsClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
 
     public interface ITransactionsClient

--- a/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class LedgerConfigurationClient : ILedgerConfigurationClient
     {

--- a/src/Daml.Ledger.Client/LedgerIdentityClient.cs
+++ b/src/Daml.Ledger.Client/LedgerIdentityClient.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class LedgerIdentityClient : ILedgerIdentityClient
     {

--- a/src/Daml.Ledger.Client/PackageClient.cs
+++ b/src/Daml.Ledger.Client/PackageClient.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class PackageClient : IPackageClient
     {

--- a/src/Daml.Ledger.Client/Testing/IResetClient.cs
+++ b/src/Daml.Ledger.Client/Testing/IResetClient.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client.Testing
 {
-    using System.Threading.Tasks;
-
     public interface IResetClient
     {
         void Reset(string accessToken = null);

--- a/src/Daml.Ledger.Client/Testing/ITimeClient.cs
+++ b/src/Daml.Ledger.Client/Testing/ITimeClient.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Daml.Ledger.Client.Testing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Testing;
 
     public interface ITimeClient

--- a/src/Daml.Ledger.Client/Testing/ResetClient.cs
+++ b/src/Daml.Ledger.Client/Testing/ResetClient.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Testing
 {
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Testing;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class ResetClient : IResetClient
     {

--- a/src/Daml.Ledger.Client/Testing/TimeClient.cs
+++ b/src/Daml.Ledger.Client/Testing/TimeClient.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client.Testing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1.Testing;
-    using Google.Protobuf.WellKnownTypes;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class TimeClient : ITimeClient
     {

--- a/src/Daml.Ledger.Client/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client/TransactionsClient.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
 namespace Daml.Ledger.Client
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Auth.Client;
-    using Grpc.Core;
 
     public class TransactionsClient : ITransactionsClient
     {

--- a/src/Daml.Ledger.Examples.Bindings/src/grpc/PingPongGrpcMain.cs
+++ b/src/Daml.Ledger.Examples.Bindings/src/grpc/PingPongGrpcMain.cs
@@ -2,34 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Linq;
-using Com.DigitalAsset.Daml_Lf_1_7.DamlLf1;
 using Grpc.Core;
-
-using ArchivePayload = Com.DigitalAsset.Daml_Lf_1_7.DamlLf.ArchivePayload;
-using Package = Com.DigitalAsset.Daml_Lf_1_7.DamlLf1.Package;
-
-using Identifier = Com.DigitalAsset.Ledger.Api.V1.Identifier;
-using CommandSubmissionService = Com.DigitalAsset.Ledger.Api.V1.CommandSubmissionService;
-using Record = Com.DigitalAsset.Ledger.Api.V1.Record;
-using RecordField = Com.DigitalAsset.Ledger.Api.V1.RecordField;
-using Command = Com.DigitalAsset.Ledger.Api.V1.Command;
-using Value = Com.DigitalAsset.Ledger.Api.V1.Value;
-using CreateCommand = Com.DigitalAsset.Ledger.Api.V1.CreateCommand;
-using SubmitRequest = Com.DigitalAsset.Ledger.Api.V1.SubmitRequest;
-using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;
-using LedgerIdentityService = Com.DigitalAsset.Ledger.Api.V1.LedgerIdentityService;
-using GetLedgerIdentityRequest = Com.DigitalAsset.Ledger.Api.V1.GetLedgerIdentityRequest;
-using PackageService = Com.DigitalAsset.Ledger.Api.V1.PackageService;
-using ListPackagesResponse = Com.DigitalAsset.Ledger.Api.V1.ListPackagesResponse;
-using ListPackagesRequest = Com.DigitalAsset.Ledger.Api.V1.ListPackagesRequest;
-using GetPackageRequest = Com.DigitalAsset.Ledger.Api.V1.GetPackageRequest;
 
 namespace Daml.Ledger.Examples.Bindings.Grpc
 {
+    using Com.DigitalAsset.Daml_Lf_1_7.DamlLf1;
+    using Com.DigitalAsset.Ledger.Api.V1;
+
     public class PingPongGrpcMain
     {
         // application id used for sending commands
@@ -149,7 +130,7 @@ namespace Daml.Ledger.Examples.Bindings.Grpc
                 submissionService.SubmitAsync(submitRequest);
             }
         }
-
+    
         /// <summary>
         /// Fetches the ledger id via the Ledger Identity Service.
         /// </summary>
@@ -187,7 +168,7 @@ namespace Daml.Ledger.Examples.Bindings.Grpc
                 try
                 {
                     // parse the archive payload
-                    ArchivePayload payload = ArchivePayload.Parser.ParseFrom(packageResponse.ArchivePayload);
+                    var payload = Com.DigitalAsset.Daml_Lf_1_7.DamlLf.ArchivePayload.Parser.ParseFrom(packageResponse.ArchivePayload);
 
                     // get the DAML LF package
                     Package lfPackage = payload.DamlLf1;

--- a/src/Daml.Ledger.Examples.Bindings/src/grpc/PingPongProcessor.cs
+++ b/src/Daml.Ledger.Examples.Bindings/src/grpc/PingPongProcessor.cs
@@ -6,26 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using Com.DigitalAsset.Ledger.Api.V1;
 using Grpc.Core;
-
-using TransactionService = Com.DigitalAsset.Ledger.Api.V1.TransactionService;
-using CommandSubmissionService = Com.DigitalAsset.Ledger.Api.V1.CommandSubmissionService;
-using Identifier = Com.DigitalAsset.Ledger.Api.V1.Identifier;
-using TransactionFilter = Com.DigitalAsset.Ledger.Api.V1.TransactionFilter;
-using Filters = Com.DigitalAsset.Ledger.Api.V1.Filters;
-using GetTransactionsRequest = Com.DigitalAsset.Ledger.Api.V1.GetTransactionsRequest;
-using LedgerOffset = Com.DigitalAsset.Ledger.Api.V1.LedgerOffset;
-using GetTransactionsResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionsResponse;
-using Transaction = Com.DigitalAsset.Ledger.Api.V1.Transaction;
-using SubmitRequest = Com.DigitalAsset.Ledger.Api.V1.SubmitRequest;
-using Commands = Com.DigitalAsset.Ledger.Api.V1.Commands;
-using Command = Com.DigitalAsset.Ledger.Api.V1.Command;
-using CreatedEvent = Com.DigitalAsset.Ledger.Api.V1.CreatedEvent;
-using Event = Com.DigitalAsset.Ledger.Api.V1.Event;
 
 namespace Daml.Ledger.Examples.Bindings.Grpc
 {
+    using Com.DigitalAsset.Ledger.Api.V1;
+
     /// This class subscribes to the stream of transactions for a given party and reacts to Ping or Pong contracts.
     public class PingPongProcessor 
     {

--- a/src/Daml.Ledger.Fragment/Loader.cs
+++ b/src/Daml.Ledger.Fragment/Loader.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.IO;
+
 namespace Daml.Ledger.Fragment
 {
-    using System;
-    using System.IO;
     using Com.DigitalAsset.Daml_Lf_1_7.DamlLf;
     using Com.DigitalAsset.Daml_Lf_1_7.DamlLf1;
 

--- a/src/Daml.Ledger.Fragment/PackageHelper.cs
+++ b/src/Daml.Ledger.Fragment/PackageHelper.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Com.DigitalAsset.Daml_Lf_1_7.DamlLf1


### PR DESCRIPTION
Declares 'solution-wide' namespaces only within the project namespace, and system/external ones outside of project namespace - so a name (such as Int64) is resolved from the solution namespaces in preference. 

Also 2 project changes to remove incorrect folders"