### PR TITLE
Reactive ledgerclient

### DIFF
--- a/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/ActiveContractsClient.cs
@@ -6,10 +6,13 @@ using System.Reactive.Concurrency;
 
 namespace Daml.Ledger.Client.Reactive
 {
-    using Com.DigitalAsset.Ledger.Api.V1;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;
- 
+
+    using GetActiveContractsResponse = Com.DigitalAsset.Ledger.Api.V1.GetActiveContractsResponse;
+    using TransactionFilter = Com.DigitalAsset.Ledger.Api.V1.TransactionFilter;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
+
     public class ActiveContractsClient
     {
         private readonly IActiveContractsClient _activeContractsClient;

--- a/src/Daml.Ledger.Client.Reactive/Admin/ConfigManagementClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/Admin/ConfigManagementClient.cs
@@ -1,0 +1,32 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace Daml.Ledger.Client.Reactive.Admin
+{
+    using Daml.Ledger.Client.Admin;
+    using Daml.Ledger.Api.Data.Util;
+
+    using TimeModel = Com.DigitalAsset.Ledger.Api.V1.Admin.TimeModel;
+
+    public class ConfigManagementClient
+    {
+        private readonly IConfigManagementClient _configManagementClient;
+
+        public ConfigManagementClient(IConfigManagementClient configManagementClient)
+        {
+            _configManagementClient = configManagementClient;
+        }
+
+        public (TimeModel, long) GetTimeModel(Optional<string> accessToken = null)
+        {
+            return _configManagementClient.GetTimeModel(accessToken?.Reduce((string) null));
+        }
+
+        public long SetTimeModel(string submissionId, long configurationGeneration, DateTime maximumRecordTime, TimeModel newTimeModel, Optional<string> accessToken = null)
+        {
+            return _configManagementClient.SetTimeModel(submissionId, configurationGeneration, maximumRecordTime, newTimeModel, accessToken?.Reduce((string) null));
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/Admin/PackageManagementClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/Admin/PackageManagementClient.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using System.Reactive.Linq;
+
+namespace Daml.Ledger.Client.Reactive.Admin
+{
+    using Daml.Ledger.Client.Admin;
+    using Daml.Ledger.Api.Data.Util;
+
+    using PackageDetails = Com.DigitalAsset.Ledger.Api.V1.Admin.PackageDetails;
+
+    public class PackageManagementClient
+    {
+        private readonly IPackageManagementClient _packageManagementClient;
+
+        public PackageManagementClient(IPackageManagementClient packageManagementClient)
+        {
+            _packageManagementClient = packageManagementClient;
+        }
+
+        public IObservable<PackageDetails> ListKnownPackages(Optional<string> accessToken = null)
+        {
+            return _packageManagementClient.ListKnownPackages(accessToken?.Reduce((string) null)).ToObservable();
+        }
+
+        void UploadDarFile(Stream stream, Optional<string> accessToken = null)
+        {
+            _packageManagementClient.UploadDarFile(stream, accessToken?.Reduce((string) null));
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/Admin/PartyManagementClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/Admin/PartyManagementClient.cs
@@ -1,0 +1,39 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Reactive.Linq;
+
+namespace Daml.Ledger.Client.Reactive.Admin
+{
+    using Daml.Ledger.Client.Admin;
+    using Daml.Ledger.Api.Data.Util;
+
+    using PartyDetails = Com.DigitalAsset.Ledger.Api.V1.Admin.PartyDetails;
+    
+    public class PartyManagementClient
+    {
+       private readonly IPartyManagementClient _partyManagementClient;
+
+        public PartyManagementClient(IPartyManagementClient partyManagementClient)
+        {
+            _partyManagementClient = partyManagementClient;
+        }
+
+        public PartyDetails AllocateParty(string displayName, string partyIdHint, Optional<string> accessToken = null)
+        {
+            return _partyManagementClient.AllocateParty(displayName, partyIdHint, accessToken?.Reduce((string) null));
+        }
+
+        string GetParticipantId(Optional<string> accessToken = null)
+        {
+            return _partyManagementClient.GetParticipantId(accessToken?.Reduce((string) null));
+
+        }
+
+        IObservable<PartyDetails> ListKnownParties(Optional<string> accessToken = null)
+        {
+            return _partyManagementClient.ListKnownParties(accessToken?.Reduce((string) null)).ToObservable();
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/DamlLedgerClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/DamlLedgerClient.cs
@@ -1,0 +1,90 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reactive.Concurrency;
+
+namespace Daml.Ledger.Client.Reactive
+{
+    /// <summary>
+    /// A ILedgerClient implementation that connects to an existing Ledger and provides clients to query it. To use the DamlLedgerClient create an instance
+    /// of DamlLedgerClient using ForLedgerIdAndHost(string, string, int, Optional), ForHostWithLedgerIdDiscovery(string, int, Optional) or
+    /// DamlLedgerClient(Optional, ManagedChannel)
+    /// When ready to use the clients, call the method Connect() to initialize the clients for that particular Ledger
+    /// Retrieve one of the clients by using a property, e.g. ActiveContractSetClient
+    /// For information on how to set up an SslContext object for mutual authentication please refer to
+    /// https://github.com/grpc/grpc-java/blob/master/SECURITY.md and the section on security in the grpc-java documentation.
+    /// </summary>
+    public class DamlLedgerClient : ILedgerClient
+    {
+        private readonly Clients _clients;
+
+        public string LedgerId => _clients.LedgerId;
+    
+        public ActiveContractsClient ActiveContractsClient { get; private set; }
+        public TransactionsClient TransactionClient { get; private set; }
+        public CommandClient CommandClient { get; private set; }
+        public CommandCompletionClient CommandCompletionClient { get; private set; }
+        public CommandSubmissionClient CommandSubmissionClient { get; private set; }
+        public LedgerIdentityClient LedgerIdentityClient { get; private set; }
+        public PackageClient PackageClient { get; private set; }
+        public LedgerConfigurationClient LedgerConfigurationClient { get; private set; }
+        public IAdminClients AdminClients { get; private set; }
+        public ITestingClients TestingClients { get; private set; }
+
+        /// <summary>
+        /// Constructor from a Daml.Ledger.Client.Client that we will provide a reactive interface to
+        /// </summary>
+        /// <param name="client"></param>
+        public DamlLedgerClient(Clients clients, IScheduler scheduler = null)
+        {
+            _clients = clients;
+
+            ActiveContractsClient = new ActiveContractsClient(_clients.ActiveContractsClient, scheduler);
+            TransactionClient = new TransactionsClient(_clients.TransactionsClient, scheduler);
+            CommandCompletionClient = new CommandCompletionClient(_clients.CommandCompletionClient, scheduler);
+            CommandSubmissionClient = new CommandSubmissionClient(_clients.CommandSubmissionClient);
+            LedgerIdentityClient = new LedgerIdentityClient(_clients.LedgerIdentityClient);
+            CommandClient = new CommandClient(_clients.CommandClient);
+            PackageClient = new PackageClient(_clients.PackageClient);
+            LedgerConfigurationClient = new LedgerConfigurationClient(_clients.LedgerConfigurationClient, scheduler);
+
+            AdminClients = new AdminClientsImpl(_clients);
+
+            TestingClients = new TestingClientsImpl(_clients);
+        }
+
+        public class AdminClientsImpl : IAdminClients
+        {
+            public AdminClientsImpl(Clients clients)
+            {
+                ConfigManagementClient = new Admin.ConfigManagementClient(clients.Admin.ConfigManagementClient);
+                PackageManagementClient = new Admin.PackageManagementClient(clients.Admin.PackageManagementClient);
+                PartyManagementClient = new Admin.PartyManagementClient(clients.Admin.PartyManagementClient);
+            }
+
+            public Admin.ConfigManagementClient ConfigManagementClient { get; }
+            public Admin.PackageManagementClient PackageManagementClient { get; }
+            public Admin.PartyManagementClient PartyManagementClient { get; }
+        }
+
+        private class TestingClientsImpl : ITestingClients
+        {
+            public TestingClientsImpl(Clients clients)
+            {
+                TimeClient = new Testing.TimeClient(clients.Testing.TimeClient);
+                ResetClient = new Testing.ResetClient(clients.Testing.ResetClient);
+            }
+
+            public Testing.TimeClient TimeClient { get; }
+            public Testing.ResetClient ResetClient { get; }
+        }
+
+        /// <summary>
+        /// Shutdown the connection
+        /// </summary>
+        public void Close()
+        {
+            _clients.Close();
+        }        
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/ILedgerClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/ILedgerClient.cs
@@ -1,0 +1,47 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Daml.Ledger.Client.Reactive
+{
+    public interface IAdminClients
+    {
+        Admin.ConfigManagementClient ConfigManagementClient { get; }
+        Admin.PackageManagementClient PackageManagementClient { get; }
+        Admin.PartyManagementClient PartyManagementClient { get; }
+    }
+
+    public interface ITestingClients
+    {
+        Testing.TimeClient TimeClient { get; }
+        Testing.ResetClient ResetClient { get; }
+    }
+
+    /// <summary>
+    /// Contains the set of services provided by a Ledger implementation
+    /// </summary>
+    public interface ILedgerClient
+    {
+        // return The identifier of the Ledger connected to this LedgerClient
+        string LedgerId { get; }
+
+        ActiveContractsClient ActiveContractsClient { get; }
+
+        TransactionsClient TransactionClient { get; }
+
+        CommandClient CommandClient { get; }
+
+        CommandCompletionClient CommandCompletionClient { get; }
+
+        CommandSubmissionClient CommandSubmissionClient { get; }
+
+        LedgerIdentityClient LedgerIdentityClient { get; }
+
+        PackageClient PackageClient { get; }
+
+        LedgerConfigurationClient LedgerConfigurationClient { get; }
+
+        ITestingClients TestingClients { get; }
+
+        IAdminClients AdminClients { get; }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/LedgerIdentityClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/LedgerIdentityClient.cs
@@ -1,0 +1,22 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Daml.Ledger.Client.Reactive
+{
+    using Daml.Ledger.Api.Data.Util;
+
+    public class LedgerIdentityClient
+    {
+        private readonly ILedgerIdentityClient _ledgerIdentityClient;
+
+        public LedgerIdentityClient(ILedgerIdentityClient ledgerIdentityClient)
+        {
+            _ledgerIdentityClient = ledgerIdentityClient;
+        }
+
+        public string GetLedgerIdentity(Optional<string> accessToken = null)
+        {
+            return _ledgerIdentityClient.GetLedgerIdentity(accessToken?.Reduce((string) null));
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/PackageClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/PackageClient.cs
@@ -1,0 +1,39 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Reactive.Linq;
+
+namespace Daml.Ledger.Client.Reactive
+{
+    using Daml.Ledger.Api.Data.Util;
+    
+    using GetPackageResponse = Com.DigitalAsset.Ledger.Api.V1.GetPackageResponse;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
+    using PackageStatus = Com.DigitalAsset.Ledger.Api.V1.PackageStatus;
+
+    public class PackageClient
+    {
+        private readonly IPackageClient _packageClient;
+
+        public PackageClient(IPackageClient packageClient)
+        {
+            _packageClient = packageClient;
+        }
+
+        public IObservable<string> ListPackages(Optional<string> accessToken = null, TraceContext traceContext = null)
+        {
+            return _packageClient.ListPackages(accessToken?.Reduce((string) null), traceContext).ToObservable();
+        }
+
+        public GetPackageResponse GetPackage(string packageId, Optional<string> accessToken = null, TraceContext traceContext = null)
+        {
+            return _packageClient.GetPackage(packageId, accessToken?.Reduce((string) null), traceContext);
+        }
+
+        public PackageStatus GetPackageStatus(string packageId, Optional<string> accessToken = null, TraceContext traceContext = null)
+        {
+            return _packageClient.GetPackageStatus(packageId, accessToken?.Reduce((string) null), traceContext);
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/Testing/ResetClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/Testing/ResetClient.cs
@@ -1,0 +1,24 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Google.Protobuf.WellKnownTypes;
+
+namespace Daml.Ledger.Client.Reactive.Testing
+{
+    using Daml.Ledger.Client.Testing;
+
+    public class ResetClient
+    {
+        private readonly IResetClient _resetClient;
+
+        public ResetClient(IResetClient resetClient)
+        {
+            _resetClient = resetClient;
+        }
+
+        void Reset()
+        {
+            _resetClient.Reset();
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/Testing/TimeClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/Testing/TimeClient.cs
@@ -1,0 +1,35 @@
+﻿// Copyright(c) 2019 Digital Asset(Switzerland) GmbH and/or its affiliates.All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+
+namespace Daml.Ledger.Client.Reactive.Testing
+{
+    using Daml.Ledger.Client.Testing;
+    using Daml.Ledger.Api.Data.Util;
+    using Util;
+
+    public class TimeClient
+    {
+        private readonly ITimeClient _timeClient;
+        private readonly IScheduler _scheduler;
+
+        public TimeClient(ITimeClient timeClient, IScheduler scheduler = null)
+        {
+            _timeClient = timeClient;
+            _scheduler = scheduler;
+        }
+
+        public void SetTime(DateTime currentTime, DateTime newTime, Optional<string> accessToken = null)
+        {
+            _timeClient.SetTime(currentTime, newTime, accessToken?.Reduce((string) null));
+        }
+
+        public IObservable<DateTimeOffset> GetTime(Optional<string> accessToken = null)
+        {
+            return _timeClient.GetTime(accessToken?.Reduce((string) null)).CreateAsyncObservable(_scheduler).Select(r => r.CurrentTime.ToDateTimeOffset());
+        }
+    }
+}

--- a/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client.Reactive/TransactionsClient.cs
@@ -9,7 +9,12 @@ namespace Daml.Ledger.Client.Reactive
     using Client;
     using Daml.Ledger.Client.Reactive.Util;
     using Daml.Ledger.Api.Data.Util;
-    using Com.DigitalAsset.Ledger.Api.V1;
+
+    using GetTransactionsResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionsResponse;
+    using TransactionFilter = Com.DigitalAsset.Ledger.Api.V1.TransactionFilter;
+    using LedgerOffset = Com.DigitalAsset.Ledger.Api.V1.LedgerOffset;
+    using TraceContext = Com.DigitalAsset.Ledger.Api.V1.TraceContext;
+    using GetTransactionTreesResponse = Com.DigitalAsset.Ledger.Api.V1.GetTransactionTreesResponse;
 
     public class TransactionsClient
     {

--- a/src/Daml.Ledger.Client.Reactive/util/ObservableLogger.cs
+++ b/src/Daml.Ledger.Client.Reactive/util/ObservableLogger.cs
@@ -8,6 +8,8 @@ namespace Daml.Ledger.Client.Reactive.Util
 {
     public class ObservableLogger
     {
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(ObservableLogger));
+
         public static IObservable<T> Log<T>(IObservable<T> observable, string name) => _logger.IsDebugEnabled ? new LoggingObservable<T>(observable, name) : observable;
 
         private class LoggingObservable<T> : IObservable<T>
@@ -66,7 +68,5 @@ namespace Daml.Ledger.Client.Reactive.Util
             private readonly string _observableName;
             private readonly IDisposable _subscription;
         }
-
-        private static readonly ILog _logger = LogManager.GetLogger(typeof(ObservableLogger));
     }
 }

--- a/src/Daml.Ledger.Client/ActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/ActiveContractsClient.cs
@@ -11,14 +11,15 @@ namespace Daml.Ledger.Client
 
     public class ActiveContractsClient : IActiveContractsClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<ActiveContractsService.ActiveContractsServiceClient> _activeContractsClient;
 
         public ActiveContractsClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _activeContractsClient = new ClientStub<ActiveContractsService.ActiveContractsServiceClient>(new ActiveContractsService.ActiveContractsServiceClient(channel), accessToken);
         }
+
+        public string LedgerId { get; }
 
         public IAsyncEnumerator<GetActiveContractsResponse> GetActiveContracts(
             TransactionFilter transactionFilter,
@@ -26,7 +27,7 @@ namespace Daml.Ledger.Client
             string accessToken = null,
             TraceContext traceContext = null)
         {
-            var request = new GetActiveContractsRequest { LedgerId = _ledgerId, Filter = transactionFilter, Verbose = verbose, TraceContext = traceContext };
+            var request = new GetActiveContractsRequest { LedgerId = LedgerId, Filter = transactionFilter, Verbose = verbose, TraceContext = traceContext };
             var response = _activeContractsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetActiveContracts(r, co));
 
             return response.ResponseStream;

--- a/src/Daml.Ledger.Client/Clients.cs
+++ b/src/Daml.Ledger.Client/Clients.cs
@@ -11,6 +11,34 @@ namespace Daml.Ledger.Client
 
     public class Clients
     {
+        private readonly Channel _channel;
+
+        public class AdminClients
+        {
+            public IConfigManagementClient ConfigManagementClient { get; }
+            public IPackageManagementClient PackageManagementClient { get; }
+            public IPartyManagementClient PartyManagementClient { get; }
+
+            public AdminClients(Channel channel, string accessToken)
+            {
+                ConfigManagementClient = new ConfigManagementClient(channel, accessToken);
+                PackageManagementClient = new PackageManagementClient(channel, accessToken);
+                PartyManagementClient = new PartyManagementClient(channel, accessToken);
+            }
+        }
+
+        public class TestingClients
+        {
+            public ITimeClient TimeClient { get; }
+            public IResetClient ResetClient { get; }
+
+            public TestingClients(string ledgerId, Channel channel, string accessToken)
+            {
+                TimeClient = new TimeClient(ledgerId, channel, accessToken);
+                ResetClient = new ResetClient(ledgerId, channel, accessToken);
+            }
+        }
+
         public string LedgerId { get; }
 
         public IActiveContractsClient       ActiveContractsClient       { get; }
@@ -73,8 +101,18 @@ namespace Daml.Ledger.Client
             }
         }
 
+        /// <summary>
+        /// Shutdown the connection
+        /// </summary>
+        public void Close()
+        {
+            _channel.ShutdownAsync().Wait();
+        }
+
         private Clients(Channel channel, string expectedLedgerId, string accessToken)
         {
+            _channel = channel;
+
             LedgerIdentityClient = new LedgerIdentityClient(channel, accessToken);
 
             LedgerId = LedgerIdentityClient.GetLedgerIdentity(accessToken);
@@ -93,32 +131,6 @@ namespace Daml.Ledger.Client
             Testing                    = new TestingClients(LedgerId, channel, accessToken);
         }
 
-        public class AdminClients
-        {
-            public IConfigManagementClient ConfigManagementClient { get; }
-            public IPackageManagementClient PackageManagementClient { get; }
-            public IPartyManagementClient PartyManagementClient { get; }
-
-            public AdminClients(Channel channel, string accessToken)
-            {
-                ConfigManagementClient = new ConfigManagementClient(channel, accessToken);
-                PackageManagementClient = new PackageManagementClient(channel, accessToken);
-                PartyManagementClient = new PartyManagementClient(channel, accessToken);
-            }
-        }
-
-        public class TestingClients
-        {
-            public ITimeClient TimeClient { get; }
-            public IResetClient ResetClient { get; }
-
-            public TestingClients(string ledgerId, Channel channel, string accessToken)
-            {
-                TimeClient = new TimeClient(ledgerId, channel, accessToken);
-                ResetClient = new ResetClient(ledgerId, channel, accessToken);
-            }
-        }
-        
         private class LedgerIdMismatchException : Exception
         {
             public LedgerIdMismatchException(string expectedLedgerId, string ledgerId)

--- a/src/Daml.Ledger.Client/CommandClient.cs
+++ b/src/Daml.Ledger.Client/CommandClient.cs
@@ -14,14 +14,15 @@ namespace Daml.Ledger.Client
 
     public class CommandClient : ICommandClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<CommandService.CommandServiceClient> _commandClient;
 
         public CommandClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _commandClient = new ClientStub<CommandService.CommandServiceClient>(new CommandService.CommandServiceClient(channel), accessToken);
         }
+
+        public string LedgerId { get; }
 
         public void SubmitAndWait(
             string applicationId,
@@ -160,7 +161,7 @@ namespace Daml.Ledger.Client
         {
             var cmds = new Commands
                 {
-                    LedgerId = _ledgerId,
+                    LedgerId = LedgerId,
                     ApplicationId = applicationId,
                     WorkflowId = workflowId,
                     CommandId = commandId,

--- a/src/Daml.Ledger.Client/CommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client/CommandCompletionClient.cs
@@ -12,18 +12,19 @@ namespace Daml.Ledger.Client
 
     public class CommandCompletionClient : ICommandCompletionClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<CommandCompletionService.CommandCompletionServiceClient> _commandCompletionClient;
 
         public CommandCompletionClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _commandCompletionClient = new ClientStub<CommandCompletionService.CommandCompletionServiceClient>(new CommandCompletionService.CommandCompletionServiceClient(channel), accessToken);
         }
 
+        public string LedgerId { get; }
+
         public IAsyncEnumerator<CompletionStreamResponse> CompletionStream(string applicationId, LedgerOffset offset, IEnumerable<string> parties, string accessToken = null)
         {
-            var request = new CompletionStreamRequest { LedgerId = _ledgerId, ApplicationId = applicationId };
+            var request = new CompletionStreamRequest { LedgerId = LedgerId, ApplicationId = applicationId };
             if (offset != null)
                 request.Offset = offset;
             request.Parties.AddRange(parties);
@@ -44,14 +45,14 @@ namespace Daml.Ledger.Client
 
         public LedgerOffset CompletionEnd(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new CompletionEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new CompletionEndRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = _commandCompletionClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.CompletionEnd(r, co));
             return response.Offset;
         }
 
         public async Task<LedgerOffset> CompletionEndAsync(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new CompletionEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new CompletionEndRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = await _commandCompletionClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.CompletionEndAsync(r, co));
             return response.Offset;
         }

--- a/src/Daml.Ledger.Client/CommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/CommandSubmissionClient.cs
@@ -14,14 +14,15 @@ namespace Daml.Ledger.Client
 
     public class CommandSubmissionClient : ICommandSubmissionClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<CommandSubmissionService.CommandSubmissionServiceClient> _commandSubmissionClient;
 
         public CommandSubmissionClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _commandSubmissionClient = new ClientStub<CommandSubmissionService.CommandSubmissionServiceClient>(new CommandSubmissionService.CommandSubmissionServiceClient(channel), accessToken);
         }
+
+        public string LedgerId { get; }
 
         public void Submit(
             string applicationId,
@@ -70,7 +71,7 @@ namespace Daml.Ledger.Client
         {
             var cmds = new Commands
             {
-                LedgerId = _ledgerId,
+                LedgerId = LedgerId,
                 ApplicationId = applicationId,
                 WorkflowId = workflowId,
                 CommandId = commandId,

--- a/src/Daml.Ledger.Client/IActiveContractsClient.cs
+++ b/src/Daml.Ledger.Client/IActiveContractsClient.cs
@@ -9,6 +9,8 @@ namespace Daml.Ledger.Client
 
     public interface IActiveContractsClient
     {
+        string LedgerId { get; }
+
         IAsyncEnumerator<GetActiveContractsResponse> GetActiveContracts(
             TransactionFilter transactionFilter,
             bool verbose = true,

--- a/src/Daml.Ledger.Client/ICommandClient.cs
+++ b/src/Daml.Ledger.Client/ICommandClient.cs
@@ -11,6 +11,8 @@ namespace Daml.Ledger.Client
 
     public interface ICommandClient
     {
+        string LedgerId { get; }
+
         void SubmitAndWait(
             string applicationId,
             string workflowId,

--- a/src/Daml.Ledger.Client/ICommandCompletionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandCompletionClient.cs
@@ -10,6 +10,8 @@ namespace Daml.Ledger.Client
 
     public interface ICommandCompletionClient
     {
+        string LedgerId { get; }
+
         IAsyncEnumerator<CompletionStreamResponse> CompletionStream(string applicationId, LedgerOffset offset, IEnumerable<string> parties, string accessToken = null);
 
         IEnumerable<CompletionStreamResponse> CompletionStreamSync(string applicationId, LedgerOffset offset, IEnumerable<string> parties, string accessToken = null);

--- a/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
+++ b/src/Daml.Ledger.Client/ICommandSubmissionClient.cs
@@ -11,6 +11,8 @@ namespace Daml.Ledger.Client
 
     public interface ICommandSubmissionClient
     {
+        string LedgerId { get; }
+
         void Submit(
             string applicationId,
             string workflowId,

--- a/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/ILedgerConfigurationClient.cs
@@ -9,6 +9,8 @@ namespace Daml.Ledger.Client
 
     public interface ILedgerConfigurationClient
     {
+        string LedgerId { get; }
+
         IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(string accessToken = null, TraceContext traceContext = null);
 
         IEnumerable<GetLedgerConfigurationResponse> GetLedgerConfigurationSync(string accessToken = null, TraceContext traceContext = null);

--- a/src/Daml.Ledger.Client/IPackageClient.cs
+++ b/src/Daml.Ledger.Client/IPackageClient.cs
@@ -10,6 +10,8 @@ namespace Daml.Ledger.Client
 
     public interface IPackageClient
     {
+        string LedgerId { get; }
+
         GetPackageResponse GetPackage(string packageId, string accessToken = null, TraceContext traceContext = null);
 
         Task<GetPackageResponse> GetPackageAsync(string packageId, string accessToken = null, TraceContext traceContext = null);

--- a/src/Daml.Ledger.Client/ITransactionsClient.cs
+++ b/src/Daml.Ledger.Client/ITransactionsClient.cs
@@ -10,6 +10,8 @@ namespace Daml.Ledger.Client
 
     public interface ITransactionsClient
     {
+        string LedgerId { get; }
+
         GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);
 
         Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null);

--- a/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
+++ b/src/Daml.Ledger.Client/LedgerConfigurationClient.cs
@@ -11,18 +11,19 @@ namespace Daml.Ledger.Client
 
     public class LedgerConfigurationClient : ILedgerConfigurationClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient> _ledgerConfigurationClient;
 
         public LedgerConfigurationClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _ledgerConfigurationClient = new ClientStub<LedgerConfigurationService.LedgerConfigurationServiceClient>(new LedgerConfigurationService.LedgerConfigurationServiceClient(channel), accessToken);
         }
 
+        public string LedgerId { get; }
+
         public IAsyncEnumerator<GetLedgerConfigurationResponse> GetLedgerConfiguration(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetLedgerConfigurationRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new GetLedgerConfigurationRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = _ledgerConfigurationClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerConfiguration(r, co));
             return response.ResponseStream;
         }

--- a/src/Daml.Ledger.Client/PackageClient.cs
+++ b/src/Daml.Ledger.Client/PackageClient.cs
@@ -12,30 +12,31 @@ namespace Daml.Ledger.Client
 
     public class PackageClient : IPackageClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<PackageService.PackageServiceClient> _packageClient;
 
         public PackageClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _packageClient = new ClientStub<PackageService.PackageServiceClient>(new PackageService.PackageServiceClient(channel), accessToken);
         }
 
+        public string LedgerId { get; }
+
         public GetPackageResponse GetPackage(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
+            var request = new GetPackageRequest { LedgerId = LedgerId, PackageId = packageId, TraceContext = traceContext };
             return _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackage(r, co));
         }
 
         public async Task<GetPackageResponse> GetPackageAsync(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetPackageRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
+            var request = new GetPackageRequest { LedgerId = LedgerId, PackageId = packageId, TraceContext = traceContext };
             return await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageAsync(r, co));
         }
 
         public PackageStatus GetPackageStatus(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
+            var request = new GetPackageStatusRequest { LedgerId = LedgerId, PackageId = packageId, TraceContext = traceContext };
             var response = _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageStatus(r, co));
 
             return response.PackageStatus;
@@ -43,21 +44,21 @@ namespace Daml.Ledger.Client
 
         public async Task<PackageStatus> GetPackageStatusAsync(string packageId, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetPackageStatusRequest { LedgerId = _ledgerId, PackageId = packageId, TraceContext = traceContext };
+            var request = new GetPackageStatusRequest { LedgerId = LedgerId, PackageId = packageId, TraceContext = traceContext };
             var response = await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetPackageStatusAsync(r, co));
             return response.PackageStatus;
         }
 
         public IEnumerable<string> ListPackages(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new ListPackagesRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.ListPackages(r, co));
             return response.PackageIds;
         }
 
         public async Task<IEnumerable<string>> ListPackagesAsync(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new ListPackagesRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new ListPackagesRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = await _packageClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.ListPackagesAsync(r, co));
             return response.PackageIds;
         }

--- a/src/Daml.Ledger.Client/TransactionsClient.cs
+++ b/src/Daml.Ledger.Client/TransactionsClient.cs
@@ -12,81 +12,82 @@ namespace Daml.Ledger.Client
 
     public class TransactionsClient : ITransactionsClient
     {
-        private readonly string _ledgerId;
         private readonly ClientStub<TransactionService.TransactionServiceClient> _transactionsClient;
 
         public TransactionsClient(string ledgerId, Channel channel, string accessToken)
         {
-            _ledgerId = ledgerId;
+            LedgerId = ledgerId;
             _transactionsClient = new ClientStub<TransactionService.TransactionServiceClient>(new TransactionService.TransactionServiceClient(channel), accessToken);
         }
 
+        public string LedgerId { get; }
+
         public GetFlatTransactionResponse GetFlatTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
+            var request = new GetTransactionByEventIdRequest { LedgerId = LedgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventId(r, co));
         }
 
         public async Task<GetFlatTransactionResponse> GetFlatTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
+            var request = new GetTransactionByEventIdRequest { LedgerId = LedgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByEventIdAsync(r, co));
         }
 
         public GetFlatTransactionResponse GetFlatTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
+            var request = new GetTransactionByIdRequest { LedgerId = LedgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionById(r, co));
         }
 
         public async Task<GetFlatTransactionResponse> GetFlatTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
+            var request = new GetTransactionByIdRequest { LedgerId = LedgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetFlatTransactionByIdAsync(r, co));
         }
 
         public LedgerOffset GetLedgerEnd(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new GetLedgerEndRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerEnd(r, co));
             return response.Offset;
         }
 
         public async Task<LedgerOffset> GetLedgerEndAsync(string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetLedgerEndRequest { LedgerId = _ledgerId, TraceContext = traceContext };
+            var request = new GetLedgerEndRequest { LedgerId = LedgerId, TraceContext = traceContext };
             var response = await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetLedgerEndAsync(r, co));
             return response.Offset;
         }
 
         public GetTransactionResponse GetTransactionByEventId(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
+            var request = new GetTransactionByEventIdRequest { LedgerId = LedgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByEventId(r, co));
         }
 
         public async Task<GetTransactionResponse> GetTransactionByEventIdAsync(string eventId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByEventIdRequest { LedgerId = _ledgerId, EventId = eventId, TraceContext = traceContext };
+            var request = new GetTransactionByEventIdRequest { LedgerId = LedgerId, EventId = eventId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByEventIdAsync(r, co));
         }
 
         public GetTransactionResponse GetTransactionById(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
+            var request = new GetTransactionByIdRequest { LedgerId = LedgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionById(r, co));
         }
 
         public async Task<GetTransactionResponse> GetTransactionByIdAsync(string transactionId, IEnumerable<string> requestingParties, string accessToken = null, TraceContext traceContext = null)
         {
-            var request = new GetTransactionByIdRequest { LedgerId = _ledgerId, TransactionId = transactionId, TraceContext = traceContext };
+            var request = new GetTransactionByIdRequest { LedgerId = LedgerId, TransactionId = transactionId, TraceContext = traceContext };
             request.RequestingParties.AddRange(requestingParties);
             return await _transactionsClient.WithAccess(accessToken).Dispatch(request, (c, r, co) => c.GetTransactionByIdAsync(r, co));
         }
@@ -101,7 +102,7 @@ namespace Daml.Ledger.Client
         {
             var request = new GetTransactionsRequest
                 {
-                    LedgerId = _ledgerId,
+                    LedgerId = LedgerId,
                     Filter = transactionFilter,
                     Begin = beginOffset,
                     End = endOffset,
@@ -139,7 +140,7 @@ namespace Daml.Ledger.Client
         {
             var request = new GetTransactionsRequest
                 {
-                    LedgerId = _ledgerId,
+                    LedgerId = LedgerId,
                     Filter = transactionFilter,
                     Begin = beginOffset,
                     End = endOffset,


### PR DESCRIPTION
Added a new reactive ledger client that wraps the reactive service interfaces, implemented in terms of the normal client ledger client. Added a close method to normal ledger client and a LedgerId property to the interfaces to the service clients. Also some namespace reorganisations.